### PR TITLE
Update README Environment Section

### DIFF
--- a/.github/ISSUE_TEMPLATE/backend-feature-template.md
+++ b/.github/ISSUE_TEMPLATE/backend-feature-template.md
@@ -22,7 +22,7 @@ Add any other context or screenshots about the feature request here.
 **BEFORE MERGING**
 - [ ] Integration test written for services
 - [ ] [Schemas annotated](https://link.com) if adding new models
-- [ ] Code generation run (*hint*: ``)
+- [ ] Code generation run (*hint*: `pnpm generate:types`)
 - [ ] Appropriate mocks created where possible
 - [ ] PR Reviewed (For non-trivial changes)
 - [ ] Changes tested after rebasing on master or merging in master (*hint*: `git fetch origin master:master`, then `git rebase master` or `git merge master`)

--- a/.github/ISSUE_TEMPLATE/backend-feature-template.md
+++ b/.github/ISSUE_TEMPLATE/backend-feature-template.md
@@ -21,7 +21,7 @@ Add any other context or screenshots about the feature request here.
 
 **BEFORE MERGING**
 - [ ] Integration test written for services
-- [ ] [Schemas annotated](https://link.com) if adding new models
+- [ ] [Schemas annotated](https://payloadcms.com/docs/configuration/collections) if adding new models
 - [ ] Code generation run (*hint*: `pnpm generate:types`)
 - [ ] Appropriate mocks created where possible
 - [ ] PR Reviewed (For non-trivial changes)

--- a/README.md
+++ b/README.md
@@ -85,10 +85,7 @@ export const add = (a: number, b: number) => a + b
 
 Environment variables are used to store sensitive information that should not be stored in the codebase. These are stored in a `.env` file in the root of the project.
 
-```
-DATABASE_URI=mongodb://127.0.0.1/your-database-name
-PAYLOAD_SECRET=YOUR_SECRET_HERE
-```
+Copy the `.env.example` file and rename it to `.env`.
 
 ### Type Generation
 


### PR DESCRIPTION
This pull request changes the environment section of README to not use a codeblock of .env.example as this would require a new PR every time the env is changed. 

Now tells developers to copy the `.env.example` file and change it to `.env`