### PR TITLE
Rename Users collection to Admin and update related references

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,9 +117,9 @@ pnpm test
 To run a single test you can use the following command
 
 ```bash
-# src/app/example-double-user-count/route.ts can be any file path that points to a test.
+# src/app/example-double-admin-count/route.ts can be any file path that points to a test.
 # Or you can replace the file path with a pattern (like a file name)
-pnpm test src/app/example-double-user-count/route.test.ts
+pnpm test src/app/example-double-admin-count/route.test.ts
 ```
 
 ## Tech Stack

--- a/src/app/example-double-admin-count/route.test.ts
+++ b/src/app/example-double-admin-count/route.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, afterEach } from 'vitest'
 
-import { GET } from '@/app/example-double-user-count/route'
+import { GET } from '@/app/example-double-admin-count/route'
 
 import dotenv from 'dotenv'
 import { clearCollection, testPayloadObject } from '../../../tests/utils'
@@ -9,12 +9,12 @@ dotenv.config()
 
 describe('double user count', () => {
   afterEach(async () => {
-    await clearCollection(testPayloadObject, 'users')
+    await clearCollection(testPayloadObject, 'admins')
   })
 
   it('should double 1 user correctly', async () => {
     await testPayloadObject.create({
-      collection: 'users',
+      collection: 'admins',
       data: {
         email: 'rayzhao@gmail.com',
         password: '12132',
@@ -27,7 +27,7 @@ describe('double user count', () => {
 
   it('should double 2 user correctly', async () => {
     await testPayloadObject.create({
-      collection: 'users',
+      collection: 'admins',
       data: {
         email: 'rayzhao@gmail.com',
         password: '12132',
@@ -35,7 +35,7 @@ describe('double user count', () => {
     })
 
     await testPayloadObject.create({
-      collection: 'users',
+      collection: 'admins',
       data: {
         email: 'straight@gmail.com',
         password: '12132',

--- a/src/app/example-double-admin-count/route.ts
+++ b/src/app/example-double-admin-count/route.ts
@@ -7,7 +7,7 @@ export const GET = async () => {
   })
 
   const data = await payload.find({
-    collection: 'users',
+    collection: 'admins',
   })
 
   return Response.json(data.docs.length * 2)

--- a/src/collections/Admin.ts
+++ b/src/collections/Admin.ts
@@ -1,7 +1,7 @@
 import type { CollectionConfig } from 'payload'
 
-export const Users: CollectionConfig = {
-  slug: 'users',
+export const Admin: CollectionConfig = {
+  slug: 'admins',
   admin: {
     useAsTitle: 'email',
   },

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -63,11 +63,11 @@ export type SupportedTimezones =
 
 export interface Config {
   auth: {
-    users: UserAuthOperations;
+    admins: AdminAuthOperations;
   };
   blocks: {};
   collections: {
-    users: User;
+    admins: Admin;
     media: Media;
     'payload-locked-documents': PayloadLockedDocument;
     'payload-preferences': PayloadPreference;
@@ -75,7 +75,7 @@ export interface Config {
   };
   collectionsJoins: {};
   collectionsSelect: {
-    users: UsersSelect<false> | UsersSelect<true>;
+    admins: AdminsSelect<false> | AdminsSelect<true>;
     media: MediaSelect<false> | MediaSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
     'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>;
@@ -87,15 +87,15 @@ export interface Config {
   globals: {};
   globalsSelect: {};
   locale: null;
-  user: User & {
-    collection: 'users';
+  user: Admin & {
+    collection: 'admins';
   };
   jobs: {
     tasks: unknown;
     workflows: unknown;
   };
 }
-export interface UserAuthOperations {
+export interface AdminAuthOperations {
   forgotPassword: {
     email: string;
     password: string;
@@ -115,9 +115,9 @@ export interface UserAuthOperations {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "users".
+ * via the `definition` "admins".
  */
-export interface User {
+export interface Admin {
   id: string;
   updatedAt: string;
   createdAt: string;
@@ -157,8 +157,8 @@ export interface PayloadLockedDocument {
   id: string;
   document?:
     | ({
-        relationTo: 'users';
-        value: string | User;
+        relationTo: 'admins';
+        value: string | Admin;
       } | null)
     | ({
         relationTo: 'media';
@@ -166,8 +166,8 @@ export interface PayloadLockedDocument {
       } | null);
   globalSlug?: string | null;
   user: {
-    relationTo: 'users';
-    value: string | User;
+    relationTo: 'admins';
+    value: string | Admin;
   };
   updatedAt: string;
   createdAt: string;
@@ -179,8 +179,8 @@ export interface PayloadLockedDocument {
 export interface PayloadPreference {
   id: string;
   user: {
-    relationTo: 'users';
-    value: string | User;
+    relationTo: 'admins';
+    value: string | Admin;
   };
   key?: string | null;
   value?:
@@ -208,9 +208,9 @@ export interface PayloadMigration {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "users_select".
+ * via the `definition` "admins_select".
  */
-export interface UsersSelect<T extends boolean = true> {
+export interface AdminsSelect<T extends boolean = true> {
   updatedAt?: T;
   createdAt?: T;
   email?: T;

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -7,7 +7,7 @@ import { buildConfig } from 'payload'
 import { fileURLToPath } from 'url'
 import sharp from 'sharp'
 
-import { Users } from './collections/Users'
+import { Admin } from './collections/Admin'
 import { Media } from './collections/Media'
 
 const filename = fileURLToPath(import.meta.url)
@@ -15,12 +15,12 @@ const dirname = path.dirname(filename)
 
 export default buildConfig({
   admin: {
-    user: Users.slug,
+    user: Admin.slug,
     importMap: {
       baseDir: path.resolve(dirname),
     },
   },
-  collections: [Users, Media],
+  collections: [Admin, Media],
   editor: lexicalEditor(),
   secret: process.env.PAYLOAD_SECRET || '',
   typescript: {


### PR DESCRIPTION
The old name `User` was not appropriate as users should not have access to the backend schema directly through the admin view