### PR TITLE
configure maxWorkers for MongoDB memory server stability in CI

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master]
 
+env:
+  CI: 'true'
+
 jobs:
   check_changes:
     name: Check Changes

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -8,5 +8,10 @@ export default defineConfig({
     environment: 'node',
     setupFiles: ['dotenv/config', './tests/mongodb-setup.ts', './tests/dom-setup'],
     globals: true,
+    /**
+     * Set this to one only so that MongoDB memory server can
+     * run without being flaky https://github.com/shelfio/jest-mongodb/issues/366
+     */
+    maxWorkers: process.env.CI === 'true' ? 1 : undefined,
   },
 })


### PR DESCRIPTION
# Description

There seemed to be some type of concurrency issue with the mongoDB tests. Hopefully this PR addresses it by limiting vitest to only have 1 worker in CI (example of fail https://github.com/UoaWDCC/uabc-web/actions/runs/14280358636/job/40029176424)

https://github.com/shelfio/jest-mongodb/issues/366

Closes #32 

## Type of change
<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [ ] Manual testing (requires screenshots or videos)
- [ ] Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added thorough tests that prove my fix is effective and that my feature works
- [ ] I've requested a review from another user
