### PR TITLE
Made migration to yamada-ui with minor styling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,4 +141,4 @@ dist
 .swc/
 
 # yamada-ui theme config
-theme/
+/theme/

--- a/src/app/(frontend)/privacy/page.tsx
+++ b/src/app/(frontend)/privacy/page.tsx
@@ -1,4 +1,4 @@
-import { Card } from '@/components/Card'
+import { Card, CardBody, Container, DiscList, Heading, ListItem, Text } from '@yamada-ui/react'
 
 export const metadata = {
   title: 'Privacy Policy - UABC Booking Portal',
@@ -7,90 +7,113 @@ export const metadata = {
 
 export default function PrivacyPolicyPage() {
   return (
-    <div className="flex min-h-dvh justify-center">
+    <Container minH="100dvh" centerContent>
       <Card
-        variant="card"
-        className="flex flex-col gap-y-2 text-pretty p-4 pt-6 sm:m-8 md:w-3/4 md:p-12 lg:w-1/2"
+        variant={{ base: 'outline', md: 'unstyled' }}
+        w="full"
+        maxW="3xl"
+        textWrap="pretty"
+        size="lg"
       >
-        <h1 className="text-3xl font-extrabold">Privacy Policy</h1>
-        <p className="my-4 text-tertiary">
-          Effective date: <strong>27th of June, 2024</strong>
-        </p>
-        <p>
-          The Web Development Consulting Club (registered charity), or WDCC, (&quot;we&quot;,
-          &quot;us&quot;, or &quot;our&quot;) operates the UABC Booking Portal web application (the
-          &quot;App&quot;). This page informs you of our policies regarding the collection, use, and
-          disclosure of personal data when you use our App and the choices you have associated with
-          that data.
-        </p>
-        <h2 className="mt-4 text-2xl font-bold">Information Collection and Use</h2>
-        <h3 className="mt-2 text-xl font-bold">Data we collect</h3>
-        <p>
-          While using our App, we may ask you to provide us with certain personally identifiable
-          information that can be used to contact or identify you (&quot;Personal Data&quot;).
-          Personally identifiable information may include, but is not limited to:
-        </p>
-        <ul className="ml-8 list-disc">
-          <li>Email address</li>
-          <li>First name and last name</li>
-          <li>Hashed Passwords</li>
-        </ul>
-        <h3 className="mt-2 text-xl font-bold">How we use your data</h3>
-        <p>We use the collected data in order to:</p>
-        <ul className="ml-8 list-disc">
-          <li>Provide and maintain the App</li>
-          <li>Let you engage with the App</li>
-          <li>Email you with information such as booking confirmations</li>
-        </ul>
-        <h3 className="mt-2 text-xl font-bold">Data Security and Retention</h3>
-        <p>
-          We prioritize the security of your data and take reasonable steps to protect it from
-          unauthorized access, disclosure, alteration, and destruction.
-        </p>
-        <p>
-          We retain Personal Data about you for as long as you have an open account with us or as
-          otherwise necessary to provide you with our services.
-        </p>
-        <h3 className="mt-2 text-xl font-bold">Information Sharing</h3>
-        <p>
-          We do not share your personal information with third parties unless required by law or as
-          necessary to provide our services.
-        </p>
-        <h3 className="mt-2 text-xl font-bold">Cookies and tracking</h3>
-        <p>
-          Cookies are small text files that are placed on your computer by the websites that you
-          visit. They are widely used in order to make websites work, or work more efficiently, as
-          well as to provide information to the owners of the site.
-        </p>
-        <p>We use the following types of Cookies:</p>
-        <ul className="ml-8 list-disc">
-          <li>
-            <strong>Required Cookies:</strong> Certain cookies are required for the App to function.
-            When you log in to the App, authentication cookies are stored to identify you and
-            maintain your session.
-          </li>
-          <li>
-            <strong>Functional Cookies:</strong> Some cookies are used to remember your preferences
-            and settings. For example your name, and choice of theme.
-          </li>
-        </ul>
-        <p>
-          The App does not use tracking cookies or any other tracking mechanisms. You may choose to
-          disable cookies from your browser settings. However, this may limit your ability to use
-          certain features of the App.
-        </p>
-        <h3 className="mt-2 text-xl font-bold">Changes to This Privacy Policy </h3>
-        <p>
-          We may update our Privacy Policy from time to time. We will notify you of any changes by
-          posting the new Privacy Policy on this page.
-        </p>
-        <h3 className="mt-2 text-xl font-bold">Contact Information</h3>
-        If you have any questions about this Privacy Policy, please do not hesitate to contact us
-        at:
-        <p className="mt-4">
-          <strong>Email:</strong> uabc@projects.wdcc.co.nz
-        </p>
+        <CardBody gap="md">
+          <Heading fontSize="3xl" fontWeight="extrabold">
+            Privacy Policy
+          </Heading>
+          <Text color="tertiary">
+            Effective date: <Text as="strong">27th of June, 2024</Text>
+          </Text>
+          <Text>
+            The Web Development Consulting Club (registered charity), or WDCC, (&quot;we&quot;,
+            &quot;us&quot;, or &quot;our&quot;) operates the UABC Booking Portal web application
+            (the &quot;App&quot;). This page informs you of our policies regarding the collection,
+            use, and disclosure of personal data when you use our App and the choices you have
+            associated with that data.
+          </Text>
+          <Heading as="h2" fontSize="2xl" fontWeight="bold">
+            Information Collection and Use
+          </Heading>
+          <Heading as="h3" fontSize="xl" fontWeight="bold">
+            Data we collect
+          </Heading>
+          <Text>
+            While using our App, we may ask you to provide us with certain personally identifiable
+            information that can be used to contact or identify you (&quot;Personal Data&quot;).
+            Personally identifiable information may include, but is not limited to:
+          </Text>
+          <DiscList>
+            <ListItem>Email address</ListItem>
+            <ListItem>First name and last name</ListItem>
+            <ListItem>Hashed Passwords</ListItem>
+          </DiscList>
+          <Heading as="h3" fontSize="xl" fontWeight="bold">
+            How we use your data
+          </Heading>
+          <Text>We use the collected data in order to:</Text>
+          <DiscList>
+            <ListItem>Provide and maintain the App</ListItem>
+            <ListItem>Let you engage with the App</ListItem>
+            <ListItem>Email you with information such as booking confirmations</ListItem>
+          </DiscList>
+          <Heading as="h3" fontSize="xl" fontWeight="bold">
+            Data Security and Retention
+          </Heading>
+          <Text>
+            We prioritize the security of your data and take reasonable steps to protect it from
+            unauthorized access, disclosure, alteration, and destruction.
+          </Text>
+          <Text>
+            We retain Personal Data about you for as long as you have an open account with us or as
+            otherwise necessary to provide you with our services.
+          </Text>
+          <Heading as="h3" fontSize="xl" fontWeight="bold">
+            Information Sharing
+          </Heading>
+          <Text>
+            We do not share your personal information with third parties unless required by law or
+            as necessary to provide our services.
+          </Text>
+          <Heading as="h3" fontSize="xl" fontWeight="bold">
+            Cookies and tracking
+          </Heading>
+          <Text>
+            Cookies are small text files that are placed on your computer by the websites that you
+            visit. They are widely used in order to make websites work, or work more efficiently, as
+            well as to provide information to the owners of the site.
+          </Text>
+          <Text>We use the following types of Cookies:</Text>
+          <DiscList>
+            <ListItem>
+              <Text as="strong">Required Cookies:</Text> Certain cookies are required for the App to
+              function. When you log in to the App, authentication cookies are stored to identify
+              you and maintain your session.
+            </ListItem>
+            <ListItem>
+              <Text as="strong">Functional Cookies:</Text> Some cookies are used to remember your
+              preferences and settings. For example your name, and choice of theme.
+            </ListItem>
+          </DiscList>
+          <Text>
+            The App does not use tracking cookies or any other tracking mechanisms. You may choose
+            to disable cookies from your browser settings. However, this may limit your ability to
+            use certain features of the App.
+          </Text>
+          <Heading as="h3" fontSize="xl" fontWeight="bold">
+            Changes to This Privacy Policy
+          </Heading>
+          <Text>
+            We may update our Privacy Policy from time to time. We will notify you of any changes by
+            posting the new Privacy Policy on this page.
+          </Text>
+          <Heading as="h3" fontSize="xl" fontWeight="bold">
+            Contact Information
+          </Heading>
+          If you have any questions about this Privacy Policy, please do not hesitate to contact us
+          at:
+          <Text>
+            <Text as="strong">Email:</Text> uabc@projects.wdcc.co.nz
+          </Text>
+        </CardBody>
       </Card>
-    </div>
+    </Container>
   )
 }

--- a/src/app/(frontend)/privacy/page.tsx
+++ b/src/app/(frontend)/privacy/page.tsx
@@ -9,7 +9,7 @@ export default function PrivacyPolicyPage() {
   return (
     <Container minH="100dvh" centerContent>
       <Card
-        variant={{ base: 'outline', md: 'unstyled' }}
+        variant={{ base: 'outline', sm: 'unstyled' }}
         w="full"
         maxW="3xl"
         textWrap="pretty"

--- a/src/app/(frontend)/providers.tsx
+++ b/src/app/(frontend)/providers.tsx
@@ -1,37 +1,11 @@
 'use client'
-import { extendConfig, extendTheme, UIProvider } from '@yamada-ui/react'
-import { Inter } from 'next/font/google'
+import { defaultTheme } from '@/theme'
+import { extendTheme, UIProvider } from '@yamada-ui/react'
 import { FC, memo, PropsWithChildren } from 'react'
 
-const inter = Inter({
-  subsets: ['latin'],
-  display: 'swap',
-  variable: '--font-inter',
-})
-
 export const Providers: FC<PropsWithChildren> = memo(({ children }) => {
-  const config = extendConfig({
-    locale: 'en-US',
-  })
-  const theme = extendTheme({
-    semantics: {
-      fonts: {
-        body: `${inter.style.fontFamily}, $fonts.body`,
-        heading: `${inter.style.fontFamily}, $fonts.heading`,
-        mono: `${inter.style.fontFamily}, $fonts.mono`,
-      },
-      colors: {
-        blue: {
-          500: 'hsl(215 52% 45%)',
-        },
-      },
-    },
-  })()
-  return (
-    <UIProvider config={config} theme={theme}>
-      {children}
-    </UIProvider>
-  )
+  const theme = extendTheme(defaultTheme)()
+  return <UIProvider theme={theme}>{children}</UIProvider>
 })
 
 Providers.displayName = 'Providers'

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,0 +1,7 @@
+import { semantics } from './semantics'
+import { tokens } from './tokens'
+
+export const defaultTheme = {
+  semantics,
+  ...tokens,
+}

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,7 +1,8 @@
+import type { UsageTheme } from '@yamada-ui/react'
 import { semantics } from './semantics'
 import { tokens } from './tokens'
 
-export const defaultTheme = {
+export const defaultTheme: UsageTheme = {
   semantics,
   ...tokens,
 }

--- a/src/theme/semantics.ts
+++ b/src/theme/semantics.ts
@@ -1,0 +1,7 @@
+import type { ThemeSemantics } from '@yamada-ui/react'
+
+export const semantics: ThemeSemantics = {
+  colors: {
+    tertiary: 'hsl(215 17% 40%)',
+  },
+}

--- a/src/theme/tokens/colors.ts
+++ b/src/theme/tokens/colors.ts
@@ -1,0 +1,7 @@
+import type { ThemeTokens } from '@yamada-ui/react'
+
+export const colors: ThemeTokens = {
+  blue: {
+    500: 'hsl(215 52% 45%)',
+  },
+}

--- a/src/theme/tokens/fonts.ts
+++ b/src/theme/tokens/fonts.ts
@@ -1,0 +1,14 @@
+import type { ThemeTokens } from '@yamada-ui/react'
+import { Inter } from 'next/font/google'
+
+const inter = Inter({
+  subsets: ['latin'],
+  display: 'swap',
+  variable: '--font-inter',
+})
+
+export const fonts: ThemeTokens = {
+  body: `${inter.style.fontFamily}, -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", "游ゴシック体", YuGothic, "YuGothic M", "Hiragino Kaku Gothic ProN", Meiryo, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"`,
+  heading: `${inter.style.fontFamily}, -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", "游ゴシック体", YuGothic, "YuGothic M", "Hiragino Kaku Gothic ProN", Meiryo, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"`,
+  mono: `${inter.style.fontFamily}, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace`,
+}

--- a/src/theme/tokens/index.ts
+++ b/src/theme/tokens/index.ts
@@ -1,0 +1,7 @@
+import { colors } from './colors'
+import { fonts } from './fonts'
+
+export const tokens = {
+  colors,
+  fonts,
+}


### PR DESCRIPTION
# Description

I have migrated the privacy policy page to Yamada UI, with minor styling.
![image](https://github.com/user-attachments/assets/c9fbd77e-1a6b-4508-b2ff-df75b5e2d477)

I have also moved theme config to its own directory to let us maintain custom themes easier as we will have our own design system soon.
I am open to any suggestions such as the global font and the fallback that we are using.

Closes #36 

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)
- [ ] Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added thorough tests that prove my fix is effective and that my feature works
- [x] I've requested a review from another user
