### PR TITLE
change matching pattern on CI pipeline to allow tests to run on code changes

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -14,7 +14,7 @@ jobs:
     name: Check Changes
     runs-on: ubuntu-latest
     outputs:
-      should_skip: ${{ steps.filter.outputs.should_skip }}
+      code_changes: ${{ steps.filter.outputs.code_changes }}
     steps:
       - uses: actions/checkout@v4
 
@@ -23,18 +23,19 @@ jobs:
         id: filter
         with:
           filters: |
-            should_skip:
-              - '**.md'
-              - '.gitignore'
-              - '.gitattributes'
-              - '.github/**'
-              - '.vscode'
-              - '.env.example'
+            code_changes:
+              - '**'
+              - '!**.md'
+              - '!.gitignore'
+              - '!.gitattributes'
+              - '!.github/**'
+              - '!.vscode/**'
+              - '!.env.example'
 
   setup:
     name: Setup
     needs: check_changes
-    if: ${{ needs.check_changes.outputs.should_skip != 'true' }}
+    if: ${{ needs.check_changes.outputs.code_changes == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -63,7 +64,7 @@ jobs:
 
   style:
     needs: [check_changes, setup]
-    if: ${{ needs.check_changes.outputs.should_skip != 'true' }}
+    if: ${{ needs.check_changes.outputs.code_changes == 'true' }}
     name: Prettier
     runs-on: ubuntu-latest
     steps:
@@ -92,7 +93,7 @@ jobs:
 
   lint:
     needs: [check_changes, setup]
-    if: ${{ needs.check_changes.outputs.should_skip != 'true' }}
+    if: ${{ needs.check_changes.outputs.code_changes == 'true' }}
     name: Lint
     runs-on: ubuntu-latest
     steps:
@@ -124,7 +125,7 @@ jobs:
 
   build:
     needs: [check_changes, setup]
-    if: ${{ needs.check_changes.outputs.should_skip != 'true' }}
+    if: ${{ needs.check_changes.outputs.code_changes == 'true' }}
     name: Build
     runs-on: ubuntu-latest
     steps:
@@ -156,7 +157,7 @@ jobs:
 
   test:
     needs: [check_changes, setup]
-    if: ${{ needs.check_changes.outputs.should_skip != 'true' }}
+    if: ${{ needs.check_changes.outputs.code_changes == 'true' }}
     name: Test
     runs-on: ubuntu-latest
     steps:
@@ -188,7 +189,7 @@ jobs:
 
   codegen:
     needs: [check_changes, setup]
-    if: ${{ needs.check_changes.outputs.should_skip != 'true' }}
+    if: ${{ needs.check_changes.outputs.code_changes == 'true' }}
     name: Codegen
     runs-on: ubuntu-latest
     steps:
@@ -237,7 +238,7 @@ jobs:
     name: Verify
     needs: [check_changes, build, lint, style, test, codegen]
     runs-on: ubuntu-latest
-    if: ${{ always() && (needs.check_changes.outputs.should_skip == 'true' || (needs.build.result == 'success' && needs.lint.result == 'success' && needs.style.result == 'success' && needs.test.result == 'success' && needs.codegen.result == 'success')) }}
+    if: ${{ always() && (needs.check_changes.outputs.code_changes != 'true' || (needs.build.result == 'success' && needs.lint.result == 'success' && needs.style.result == 'success' && needs.test.result == 'success' && needs.codegen.result == 'success')) }}
     steps:
       - name: All checks passed
         run: echo "All checks passed!"

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -13,8 +13,6 @@ jobs:
   check_changes:
     name: Check Changes
     runs-on: ubuntu-latest
-    outputs:
-      exists: ${{ steps.filter.outputs.exists }}
     steps:
       - uses: actions/checkout@v4
 
@@ -23,7 +21,6 @@ jobs:
         id: filter
         with:
           patterns: |
-            exists:
               '**'
               '!**.md'
               '!.gitignore'

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -14,28 +14,28 @@ jobs:
     name: Check Changes
     runs-on: ubuntu-latest
     outputs:
-      code_changes: ${{ steps.filter.outputs.code_changes }}
+      exists: ${{ steps.filter.outputs.exists }}
     steps:
       - uses: actions/checkout@v4
 
       - name: Filter changes
-        uses: dorny/paths-filter@v2
+        uses: yumemi-inc/path-filter@v2
         id: filter
         with:
-          filters: |
-            code_changes:
-              - '**'
-              - '!**.md'
-              - '!.gitignore'
-              - '!.gitattributes'
-              - '!.github/**'
-              - '!.vscode/**'
-              - '!.env.example'
+          patterns: |
+            exists:
+              '**'
+              '!**.md'
+              '!.gitignore'
+              '!.gitattributes'
+              '!.github/**'
+              '!.vscode/**'
+              '!.env.example'
 
   setup:
     name: Setup
     needs: check_changes
-    if: ${{ needs.check_changes.outputs.code_changes == 'true' }}
+    if: ${{ needs.check_changes.outputs.exists == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -64,7 +64,7 @@ jobs:
 
   style:
     needs: [check_changes, setup]
-    if: ${{ needs.check_changes.outputs.code_changes == 'true' }}
+    if: ${{ needs.check_changes.outputs.exists == 'true' }}
     name: Prettier
     runs-on: ubuntu-latest
     steps:
@@ -93,7 +93,7 @@ jobs:
 
   lint:
     needs: [check_changes, setup]
-    if: ${{ needs.check_changes.outputs.code_changes == 'true' }}
+    if: ${{ needs.check_changes.outputs.exists == 'true' }}
     name: Lint
     runs-on: ubuntu-latest
     steps:
@@ -125,7 +125,7 @@ jobs:
 
   build:
     needs: [check_changes, setup]
-    if: ${{ needs.check_changes.outputs.code_changes == 'true' }}
+    if: ${{ needs.check_changes.outputs.exists == 'true' }}
     name: Build
     runs-on: ubuntu-latest
     steps:
@@ -157,7 +157,7 @@ jobs:
 
   test:
     needs: [check_changes, setup]
-    if: ${{ needs.check_changes.outputs.code_changes == 'true' }}
+    if: ${{ needs.check_changes.outputs.exists == 'true' }}
     name: Test
     runs-on: ubuntu-latest
     steps:
@@ -189,7 +189,7 @@ jobs:
 
   codegen:
     needs: [check_changes, setup]
-    if: ${{ needs.check_changes.outputs.code_changes == 'true' }}
+    if: ${{ needs.check_changes.outputs.exists == 'true' }}
     name: Codegen
     runs-on: ubuntu-latest
     steps:
@@ -238,7 +238,7 @@ jobs:
     name: Verify
     needs: [check_changes, build, lint, style, test, codegen]
     runs-on: ubuntu-latest
-    if: ${{ always() && (needs.check_changes.outputs.code_changes != 'true' || (needs.build.result == 'success' && needs.lint.result == 'success' && needs.style.result == 'success' && needs.test.result == 'success' && needs.codegen.result == 'success')) }}
+    if: ${{ always() && (needs.check_changes.outputs.exists != 'true' || (needs.build.result == 'success' && needs.lint.result == 'success' && needs.style.result == 'success' && needs.test.result == 'success' && needs.codegen.result == 'success')) }}
     steps:
       - name: All checks passed
         run: echo "All checks passed!"

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -13,5 +13,6 @@ export default defineConfig({
      * run without being flaky https://github.com/shelfio/jest-mongodb/issues/366
      */
     maxWorkers: process.env.CI === 'true' ? 1 : undefined,
+    minWorkers: process.env.CI === 'true' ? 1 : undefined,
   },
 })


### PR DESCRIPTION
# Description

The main issue is in the should_skip filter, which is incorrectly configured. The current implementation skips all checks if a single file like a markdown file or config file changes, even if code files were also changed. Instead, we need to separate the filtering logic to skip only when exclusively non-code files changed.

## Type of change
<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [ ] Manual testing (requires screenshots or videos)
- [ ] Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added thorough tests that prove my fix is effective and that my feature works
- [ ] I've requested a review from another user
