### PR TITLE
Migrated admin root page tailwind to Yamada UI

### DIFF
--- a/src/app/(frontend)/admin/page.tsx
+++ b/src/app/(frontend)/admin/page.tsx
@@ -1,9 +1,9 @@
-import { CalendarClock, CalendarDays, Users } from 'lucide-react'
-import { BsPersonFillCheck } from 'react-icons/bs'
+import { CalendarClockIcon, CalendarDaysIcon, UserCheckIcon, UsersIcon } from '@yamada-ui/lucide'
 
 import { DashboardButton } from '@/components/admin/DashboardButton'
 import { MemberApprovalPing } from '@/components/admin/members/MemberApprovalPing'
 import { Heading } from '@/components/Heading'
+import { Container, VStack } from '@yamada-ui/react'
 
 export const metadata = {
   title: 'Admin Dashboard - UABC Booking Portal',
@@ -11,27 +11,39 @@ export const metadata = {
 
 export default async function AdminDashboardPage() {
   return (
-    <div className="flex h-dvh flex-col">
-      <div className="flex p-4">
+    <Container h="100dvh">
+      <VStack>
         <Heading>Dashboard</Heading>
-      </div>
-      <div className="flex flex-col gap-4 px-4">
-        <DashboardButton href="/admin/view-sessions">
-          <CalendarDays size={24} className="min-w-6" />
+        <DashboardButton
+          href="/admin/view-sessions"
+          startIcon={<CalendarDaysIcon fontSize={24} minW="6" />}
+        >
           View Sessions
         </DashboardButton>
-        <DashboardButton href="/admin/semesters">
-          <CalendarClock size={24} className="min-w-6" />
+        <DashboardButton
+          href="/admin/semesters"
+          startIcon={<CalendarClockIcon fontSize={24} minW="6" />}
+        >
           Edit Semester Schedules
         </DashboardButton>
-        <DashboardButton href="/admin/members" className="relative">
-          <Users size={24} className="min-w-6" /> Manage Members
+        <DashboardButton
+          href="/admin/members"
+          className="relative"
+          startIcon={<UsersIcon fontSize={24} minW="6" />}
+        >
+          Manage Members
         </DashboardButton>
-        <DashboardButton href="/admin/member-approval" className="relative">
+        {/* TODO: Possibly replace with lucide icon */}
+        <DashboardButton
+          href="/admin/member-approval"
+          className="relative"
+          startIcon={<UserCheckIcon fontSize={24} minW="6" />}
+        >
           <MemberApprovalPing />
-          <BsPersonFillCheck size={24} className="min-w-6" /> Approve Members
+          {/* <BsPersonFillCheck size={24} /> */}
+          Approve Members
         </DashboardButton>
-      </div>
-    </div>
+      </VStack>
+    </Container>
   )
 }

--- a/src/app/(frontend)/admin/view-sessions/[gameSessionId]/client-page.tsx
+++ b/src/app/(frontend)/admin/view-sessions/[gameSessionId]/client-page.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import React from 'react'
-import { Download } from 'lucide-react'
 
 import { AttendeesTable } from '@/components/admin/view-sessions/gameSessionId/AttendeesList'
 import { BackNavigationBar } from '@/components/BackNavigationBar'
@@ -9,6 +8,7 @@ import { Button } from '@/components/ui/button'
 import { toast } from '@/components/ui/use-toast'
 import { useGameSessionId } from '@/hooks/query/game-sessions'
 import { formatFullDate } from '@/lib/utils/dates'
+import { DownloadIcon } from '@yamada-ui/lucide'
 
 export default function ClientViewSessionsPageWithId({ gameSessionId }: { gameSessionId: number }) {
   const { data, isLoading } = useGameSessionId(gameSessionId)
@@ -51,7 +51,7 @@ export default function ClientViewSessionsPageWithId({ gameSessionId }: { gameSe
               onClick={handleDownloadcsv}
               variant="outline"
             >
-              <Download size={16} />
+              <DownloadIcon />
               Download as CSV
             </Button>
           </h1>

--- a/src/components/Heading.tsx
+++ b/src/components/Heading.tsx
@@ -2,13 +2,16 @@
  * @author Angela Guo <aguo921@aucklanduni.ac.nz>
  */
 
-import { cn } from '@/lib/utils'
+import { type HeadingProps, Heading as UIHeading } from '@yamada-ui/react'
+import type { FC } from 'react'
 
-interface HeadingProps {
-  children: string
-  className?: string
-}
-
-export const Heading = ({ children, className }: HeadingProps) => (
-  <h1 className={cn('text-3xl font-bold tracking-tight', className)}>{children}</h1>
+export const Heading: FC<HeadingProps> = ({ children, ...props }: HeadingProps) => (
+  <UIHeading
+    fontSize="3xl"
+    fontWeight="bold"
+    // className={cn('text-3xl font-bold tracking-tight', className)}
+    {...props}
+  >
+    {children}
+  </UIHeading>
 )

--- a/src/components/Icons.tsx
+++ b/src/components/Icons.tsx
@@ -1,16 +1,15 @@
-import type { HTMLAttributes } from 'react'
+import { Icon, type IconProps } from '@yamada-ui/react'
+import type { FC } from 'react'
 
-type IconProps = HTMLAttributes<SVGElement>
-
-export const ArrowRight = (props: IconProps) => (
-  <svg
+export const ArrowRightIcon: FC<IconProps> = (props) => (
+  <Icon
     width="32"
     height="16"
     viewBox="1 0 32 16"
-    fill="none"
+    fill="currentColor"
     xmlns="http://www.w3.org/2000/svg"
     {...props}
   >
     <path d="M32.7071 8.70711C33.0976 8.31658 33.0976 7.68342 32.7071 7.29289L26.3431 0.928932C25.9526 0.538408 25.3195 0.538408 24.9289 0.928932C24.5384 1.31946 24.5384 1.95262 24.9289 2.34315L30.5858 8L24.9289 13.6569C24.5384 14.0474 24.5384 14.6805 24.9289 15.0711C25.3195 15.4616 25.9526 15.4616 26.3431 15.0711L32.7071 8.70711ZM0 9H32V7H0V9Z" />
-  </svg>
+  </Icon>
 )

--- a/src/components/admin/DashboardButton.tsx
+++ b/src/components/admin/DashboardButton.tsx
@@ -1,29 +1,19 @@
 import React from 'react'
 import Link from 'next/link'
 
-import { cn } from '@/lib/utils'
-import { ArrowRight } from '../Icons'
+import { ArrowRightIcon } from '../Icons'
+import { Button, Spacer, type ButtonProps } from '@yamada-ui/react'
 
-interface DashboardButtonProps {
-  children: React.ReactNode
+interface DashboardButtonProps extends ButtonProps {
   href: string
-  className?: string
 }
 
-export function DashboardButton({ children, href, className }: DashboardButtonProps) {
+export function DashboardButton({ children, href, ...props }: DashboardButtonProps) {
   return (
-    <>
-      <Link href={href}>
-        <div
-          className={cn(
-            'relative flex h-20 items-center gap-4 rounded-sm bg-primary pl-6 pr-16 text-lg font-medium text-primary-foreground',
-            className,
-          )}
-        >
-          {children}
-          <ArrowRight className="absolute bottom-6 right-4 fill-primary-foreground" />
-        </div>
-      </Link>
-    </>
+    <Button as={Link} href={href} colorScheme="primary" rounded="md" h="20" px="6" {...props}>
+      {children}
+      <Spacer />
+      <ArrowRightIcon h="8" w="8" />
+    </Button>
   )
 }


### PR DESCRIPTION
# Description

I have migrated the `/admin` page to Yamada UI.
I intentionally did not change `<MemberApprovalPing />` because I don't know the original location pre-migration. This can be done later.
Some implementation such as `tracking-tight` is a tailwind custom styling, so I have left it commented out in case we need to refer it back later.

![image](https://github.com/user-attachments/assets/0c9fa9a7-b2e0-481e-bcba-ad5dc05651aa)

Closes #40

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)
- [ ] Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added thorough tests that prove my fix is effective and that my feature works
- [x] I've requested a review from another user
