### PR TITLE
refactor(member-management): make pagination not re-render when it is unchanged

### DIFF
--- a/src/components/admin/members/MemberManagementTable/Columns.tsx
+++ b/src/components/admin/members/MemberManagementTable/Columns.tsx
@@ -1,0 +1,86 @@
+import type { Member } from '@/types/member'
+import { Button, HStack, Text } from '@yamada-ui/react'
+import type { Column } from '@yamada-ui/table'
+import { memo, useCallback } from 'react'
+
+const NameCell = memo(({ value }: { value: string }) => (
+  <Text as="span" lineClamp={1}>
+    {value}
+  </Text>
+))
+
+NameCell.displayName = 'NameCell'
+
+export const NAME_COLUMN: Column<Member> = {
+  accessorKey: 'name',
+  header: 'Name',
+  css: { w: '200px' },
+  cell: ({ getValue }) => {
+    const value = getValue() as string
+    return <NameCell value={value} />
+  },
+}
+
+const EmailCell = memo(({ value }: { value: string }) => (
+  <Text as="span" lineClamp={1}>
+    {value}
+  </Text>
+))
+
+EmailCell.displayName = 'EmailCell'
+
+export const EMAIL_COLUMN: Column<Member> = {
+  accessorKey: 'email',
+  header: 'Email',
+  cell: ({ getValue }) => {
+    const value = getValue() as string
+    return <EmailCell value={value} />
+  },
+}
+
+const PrepaidSessionsCell = memo(({ value }: { value: number }) => (
+  <Text as="span" textAlign="center" display="block">
+    {value}
+  </Text>
+))
+
+PrepaidSessionsCell.displayName = 'PrepaidSessionsCell'
+
+export const PREPAID_SESSIONS_COLUMN: Column<Member> = {
+  accessorKey: 'prepaidSessions',
+  header: 'Prepaid Sessions',
+  css: { minW: '200px', textAlign: 'center' },
+  cell: ({ getValue }) => {
+    const value = getValue() as number
+    return <PrepaidSessionsCell value={value} />
+  },
+}
+
+const EditButton = memo(() => {
+  const handleClick = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation()
+  }, [])
+
+  return (
+    <Button size="sm" variant="outline" onClick={handleClick}>
+      Edit
+    </Button>
+  )
+})
+
+EditButton.displayName = 'EditButton'
+
+const ActionsCell = memo(() => (
+  <HStack justify="center">
+    <EditButton />
+  </HStack>
+))
+
+ActionsCell.displayName = 'ActionsCell'
+
+export const ACTIONS_COLUMN: Column<Member> = {
+  id: 'actions',
+  header: 'Actions',
+  css: { w: '200px', textAlign: 'center' },
+  cell: () => <ActionsCell />,
+}

--- a/src/components/admin/members/MemberManagementTable/Filter.tsx
+++ b/src/components/admin/members/MemberManagementTable/Filter.tsx
@@ -8,22 +8,16 @@ import { FilterResetButton } from './FilterResetButton'
 
 type FilterProps = {
   filterRef: RefObject<(value: string) => void>
-  resetRef: RefObject<() => void>
 }
 
-export const Filter = memo(({ filterRef, resetRef }: FilterProps) => {
-  const prevHasValueRef = useRef<boolean>(false)
-  const showResetRef = useRef<() => void>(noop)
+export const Filter = memo(({ filterRef }: FilterProps) => {
+  const hasFilterRef = useRef<(hasValue: boolean) => void>(noop)
+  const resetFilterRef = useRef<() => void>(noop)
 
   return (
     <HStack gap="sm">
-      <FilterInput
-        resetRef={resetRef}
-        filterRef={filterRef}
-        prevHasValueRef={prevHasValueRef}
-        showResetRef={showResetRef}
-      />
-      <FilterResetButton showResetRef={showResetRef} resetRef={resetRef} />
+      <FilterInput passHasRef={hasFilterRef} passValueRef={filterRef} resetRef={resetFilterRef} />
+      <FilterResetButton hasFilterRef={hasFilterRef} resetFilterRef={resetFilterRef} />
     </HStack>
   )
 })

--- a/src/components/admin/members/MemberManagementTable/FilterInput.tsx
+++ b/src/components/admin/members/MemberManagementTable/FilterInput.tsx
@@ -1,46 +1,38 @@
 import { assignRef, Input } from '@yamada-ui/react'
-import { FC, memo, useState } from 'react'
+import { type FC, memo, type RefObject, useRef } from 'react'
 
 interface FilterInputProps {
-  resetRef: React.RefObject<() => void>
-  filterRef: React.RefObject<(value: string) => void>
-  prevHasValueRef: React.RefObject<boolean>
-  showResetRef: React.RefObject<(value: boolean) => void>
+  passHasRef: RefObject<(hasValue: boolean) => void>
+  passValueRef: RefObject<(value: string) => void>
+  resetRef: RefObject<() => void>
 }
 
-export const FilterInput: FC<FilterInputProps> = memo(
-  ({ resetRef, filterRef, prevHasValueRef, showResetRef }) => {
-    const [value, setValue] = useState<string>('')
-    assignRef(resetRef, () => {
-      setValue('')
+export const FilterInput: FC<FilterInputProps> = memo(({ passHasRef, passValueRef, resetRef }) => {
+  const inputRef = useRef<HTMLInputElement>(null)
+  assignRef(resetRef, () => {
+    if (inputRef.current) {
+      inputRef.current.value = ''
+    }
 
-      setTimeout(() => {
-        // Trigger parent component's filter with empty string to show all items
-        filterRef.current('')
-      })
+    setTimeout(() => {
+      // Trigger parent component's filter with empty string to show all items
+      passValueRef.current('')
+      passHasRef.current(false)
     })
-    return (
-      <Input
-        placeholder="Filter members..."
-        value={value}
-        onChange={(ev) => {
-          setValue(ev.target.value)
-          const hasValue = !!ev.target.value
-          prevHasValueRef.current = hasValue
-          if (hasValue) {
-            showResetRef.current(true)
-          } else {
-            showResetRef.current(false)
-          }
-
-          setTimeout(() => {
-            filterRef.current(ev.target.value)
-          })
-        }}
-        w="300px"
-      />
-    )
-  },
-)
+  })
+  return (
+    <Input
+      ref={inputRef}
+      placeholder="Filter members..."
+      onChange={(ev) => {
+        setTimeout(() => {
+          passValueRef.current(ev.target.value)
+          passHasRef.current(!!ev.target.value)
+        })
+      }}
+      w="300px"
+    />
+  )
+})
 
 FilterInput.displayName = 'FilterInput'

--- a/src/components/admin/members/MemberManagementTable/FilterResetButton.tsx
+++ b/src/components/admin/members/MemberManagementTable/FilterResetButton.tsx
@@ -1,33 +1,38 @@
 import { XIcon } from '@yamada-ui/lucide'
 import { assignRef, Button, useBoolean } from '@yamada-ui/react'
-import { FC, memo } from 'react'
+import { type FC, memo, type RefObject, useCallback, useRef } from 'react'
 
 interface FilterResetButtonProps {
-  resetRef: React.RefObject<() => void>
-  showResetRef: React.RefObject<(value: boolean) => void>
+  hasFilterRef: RefObject<(hasValue: boolean) => void>
+  resetFilterRef: RefObject<() => void>
 }
 
-export const FilterResetButton: FC<FilterResetButtonProps> = memo(({ resetRef, showResetRef }) => {
-  const [isShow, { off, on }] = useBoolean()
-  assignRef(showResetRef, (hasValue) => {
-    if (hasValue) {
-      on()
-    } else {
-      off()
-    }
-  })
-  if (!isShow) return null
-  return (
-    <Button
-      variant="ghost"
-      endIcon={<XIcon />}
-      onClick={() => {
-        resetRef.current()
-      }}
-    >
-      Reset
-    </Button>
-  )
-})
+export const FilterResetButton: FC<FilterResetButtonProps> = memo(
+  ({ hasFilterRef, resetFilterRef }) => {
+    const [isShow, { off, on }] = useBoolean()
+    const prevHasFilterRef = useRef<boolean>(false)
+
+    const onReset = useCallback(() => {
+      resetFilterRef.current()
+    }, [resetFilterRef])
+
+    assignRef(hasFilterRef, (hasValue) => {
+      prevHasFilterRef.current = hasValue
+
+      if (hasValue) {
+        on()
+      } else {
+        off()
+      }
+    })
+
+    if (!isShow) return null
+    return (
+      <Button variant="ghost" endIcon={<XIcon />} onClick={onReset}>
+        Reset
+      </Button>
+    )
+  },
+)
 
 FilterResetButton.displayName = 'FilterResetButton'

--- a/src/components/admin/members/MemberManagementTable/PagingTable.tsx
+++ b/src/components/admin/members/MemberManagementTable/PagingTable.tsx
@@ -1,0 +1,46 @@
+import { noop, TableContainer } from '@yamada-ui/react'
+import { type FC, memo, type RefObject, useCallback, useRef } from 'react'
+import { MemberManagementTable } from './Table'
+import { TablePagination } from './TablePagination'
+
+interface PagingTableProps {
+  filterRef: RefObject<(value: string) => void>
+}
+
+export const PagingTable: FC<PagingTableProps> = memo(({ filterRef }) => {
+  const totalPageRef = useRef<(value: number) => void>(noop) // total pages for pagination
+  const perPageRef = useRef<(value: number) => void>(noop) // number of items per page
+  const currentPageRef = useRef<(value: number) => void>(noop) // current page number
+
+  const onTotalPageChange = useCallback((value: number) => {
+    totalPageRef.current(value)
+  }, [])
+
+  const onPerPageChange = useCallback((value: number) => {
+    perPageRef.current(value)
+  }, [])
+
+  const onPageChange = useCallback((value: number) => {
+    currentPageRef.current(value)
+  }, [])
+
+  return (
+    <>
+      <TableContainer>
+        <MemberManagementTable
+          filterRef={filterRef}
+          perPageRef={perPageRef}
+          currentPageRef={currentPageRef}
+          onTotalPageChange={onTotalPageChange}
+        />
+      </TableContainer>
+      <TablePagination
+        totalPageRef={totalPageRef}
+        onPerPageChange={onPerPageChange}
+        onPageChange={onPageChange}
+      />
+    </>
+  )
+})
+
+PagingTable.displayName = 'PagingTable'

--- a/src/components/admin/members/MemberManagementTable/SkeletonTable.tsx
+++ b/src/components/admin/members/MemberManagementTable/SkeletonTable.tsx
@@ -1,0 +1,50 @@
+import { type FC, memo } from 'react'
+import {
+  TableContainer,
+  NativeTable,
+  Thead,
+  Tr,
+  Th,
+  Center,
+  Checkbox,
+  Tbody,
+  Td,
+  Loading,
+} from '@yamada-ui/react'
+
+export const SkeletonTable: FC = memo(() => {
+  return (
+    <TableContainer>
+      <NativeTable borderCollapse="separate" borderWidth="1px" rounded="md">
+        <Thead>
+          <Tr>
+            <Th w="0" px="3" py="2">
+              <Center h="full">
+                <Checkbox disabled />
+              </Center>
+            </Th>
+            <Th w="200px">Name</Th>
+            <Th>Email</Th>
+            <Th w="150px" textAlign="center">
+              Prepaid Sessions
+            </Th>
+            <Th w="150px" textAlign="center">
+              Actions
+            </Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          <Tr>
+            <Td colSpan={5} h="3xs">
+              <Center h="full">
+                <Loading fontSize="5xl" />
+              </Center>
+            </Td>
+          </Tr>
+        </Tbody>
+      </NativeTable>
+    </TableContainer>
+  )
+})
+
+SkeletonTable.displayName = 'SkeletonTable'

--- a/src/components/admin/members/MemberManagementTable/Table.tsx
+++ b/src/components/admin/members/MemberManagementTable/Table.tsx
@@ -4,151 +4,171 @@ import type { TdProps } from '@yamada-ui/react'
 import type { Cell, Column, PagingTableProps } from '@yamada-ui/table'
 import { useMembers } from '@/hooks/query/useMembers'
 import type { Member } from '@/types/member'
-import { useMemo, useState, memo, RefObject } from 'react'
+import type { RefObject, FC, Reducer } from 'react'
+import { useMemo, memo, useReducer, useEffect } from 'react'
 import { assignRef } from '@yamada-ui/react'
-import { Button, HStack, Text, Center, Loading } from '@yamada-ui/react'
-import { PagingTable } from '@yamada-ui/table'
+import { Table } from '@yamada-ui/table'
+import { ACTIONS_COLUMN, EMAIL_COLUMN, NAME_COLUMN, PREPAID_SESSIONS_COLUMN } from './Columns'
+import { SkeletonTable } from './SkeletonTable'
 
 export interface MemberManagementTableProps {
   filterRef: RefObject<(value: string) => void>
+  perPageRef: RefObject<(value: number) => void>
+  currentPageRef: RefObject<(value: number) => void>
+  onTotalPageChange: (value: number) => void
 }
 
-export const MemberManagementTable = memo(({ filterRef }: MemberManagementTableProps) => {
-  const { data, isLoading } = useMembers()
-  const [filterValue, setFilterValue] = useState('')
+type State = {
+  filterValue: string
+  currentPage: number
+  totalPerPage: number
+}
 
-  const members = useMemo(
-    () =>
-      data?.map((member) => ({
-        id: member.id,
-        name: `${member.firstName} ${member.lastName}`,
-        email: member.email,
-        prepaidSessions: member.prepaidSessions,
-      })),
-    [data],
-  )
+type Action =
+  | { type: 'SET_FILTER'; payload: string }
+  | { type: 'SET_PAGE'; payload: number }
+  | { type: 'SET_PAGE_SIZE'; payload: number }
 
-  const filteredMembers = useMemo(() => {
-    if (!filterValue) return members
-    const lowercaseFilter = filterValue.toLowerCase()
-    return members?.filter(
-      (member) =>
-        member.name.toLowerCase().includes(lowercaseFilter) ||
-        member.email.toLowerCase().includes(lowercaseFilter) ||
-        member.prepaidSessions.toString().includes(lowercaseFilter),
-    )
-  }, [members, filterValue])
-
-  const columns = useMemo<Column<Member>[]>(
-    () => [
-      {
-        accessorKey: 'name',
-        header: 'Name',
-        css: { w: '200px' },
-        cell: ({ getValue }) => (
-          <Text as="span" lineClamp={1}>
-            {getValue() as string}
-          </Text>
-        ),
-      },
-      {
-        accessorKey: 'email',
-        header: 'Email',
-        cell: ({ getValue }) => (
-          <Text as="span" lineClamp={1}>
-            {getValue() as string}
-          </Text>
-        ),
-      },
-      {
-        accessorKey: 'prepaidSessions',
-        header: 'Prepaid Sessions',
-        css: { w: '200px', textAlign: 'center' },
-        cell: ({ getValue }) => (
-          <Text as="span" textAlign="center" display="block">
-            {getValue() as number}
-          </Text>
-        ),
-      },
-      {
-        id: 'actions',
-        header: 'Actions',
-        css: { w: '200px', textAlign: 'center' },
-        cell: () => (
-          <HStack justify="center">
-            <Button size="sm" variant="outline">
-              Edit
-            </Button>
-          </HStack>
-        ),
-      },
-    ],
-    [],
-  )
-
-  const cellProps = useMemo<PagingTableProps<Member>['cellProps']>(() => {
-    return ({ column, row }: Cell<Member & { empty?: boolean }, unknown>) => {
-      const props: TdProps = { verticalAlign: 'middle' }
-
-      if (row.original.empty) {
-        if (column.columnDef.header === 'Name') {
-          props.colSpan = 5
-          props.textAlign = 'center'
-          props.color = 'muted'
-          props.h = '3xs'
-        } else {
-          props.display = 'none'
-        }
-      }
-
-      if (column.columnDef.header === 'Actions') {
-        props.py = 2
-      }
-
-      return props
-    }
-  }, [])
-
-  assignRef(filterRef, setFilterValue)
-
-  if (isLoading) {
-    return (
-      <Center>
-        <Loading fontSize="5xl" />
-      </Center>
-    )
+const reducer: Reducer<State, Action> = (state, action) => {
+  switch (action.type) {
+    case 'SET_FILTER':
+      return { ...state, filterValue: action.payload, currentPage: 1 }
+    case 'SET_PAGE':
+      return { ...state, currentPage: action.payload }
+    case 'SET_PAGE_SIZE':
+      return { ...state, totalPerPage: action.payload, currentPage: 1 }
+    default:
+      return state
   }
+}
 
-  const hasData = !!filteredMembers?.length
+export const MemberManagementTable: FC<MemberManagementTableProps> = memo(
+  ({ filterRef, perPageRef, currentPageRef, onTotalPageChange }) => {
+    const { data, isLoading } = useMembers()
 
-  const resolvedData = hasData
-    ? filteredMembers
-    : [
-        {
-          id: '',
-          name: 'No members found',
-          email: '',
-          prepaidSessions: 0,
-          empty: true,
-        },
-      ]
+    const [state, dispatch] = useReducer(reducer, {
+      filterValue: '',
+      currentPage: 1,
+      totalPerPage: 20,
+    })
 
-  return (
-    <PagingTable<Member & { empty?: boolean }>
-      sx={{ 'tbody > tr:last-of-type > td': { borderBottomWidth: '0px' } }}
-      borderCollapse="separate"
-      borderWidth="1px"
-      columns={columns}
-      data={resolvedData}
-      rowId="id"
-      cellProps={cellProps}
-      withPagingControl={hasData}
-      highlightOnHover={hasData}
-      highlightOnSelected={hasData}
-      rowsClickSelect={hasData}
-      rounded="md"
-    />
-  )
-})
+    const { filterValue, currentPage, totalPerPage } = state
+
+    const members = useMemo(
+      () =>
+        data?.map((member) => ({
+          id: member.id,
+          name: `${member.firstName} ${member.lastName}`,
+          email: member.email,
+          prepaidSessions: member.prepaidSessions,
+        })) ?? [],
+      [data],
+    )
+
+    const filteredMembers = useMemo(() => {
+      if (!filterValue) {
+        return members
+      }
+      const lowercaseFilter = filterValue.toLowerCase()
+      const filtered = members.filter(
+        (member) =>
+          member.name.toLowerCase().includes(lowercaseFilter) ||
+          member.email.toLowerCase().includes(lowercaseFilter) ||
+          member.prepaidSessions.toString().includes(lowercaseFilter),
+      )
+      return filtered
+    }, [members, filterValue])
+
+    const totalPages = useMemo(() => {
+      return Math.ceil(filteredMembers.length / totalPerPage)
+    }, [filteredMembers, totalPerPage])
+
+    const paginatedMembers = useMemo(() => {
+      const startIndex = (currentPage - 1) * totalPerPage
+      const endIndex = startIndex + totalPerPage
+      return filteredMembers.slice(startIndex, endIndex)
+    }, [filteredMembers, currentPage, totalPerPage])
+
+    const columns = useMemo<Column<Member>[]>(
+      () => [NAME_COLUMN, EMAIL_COLUMN, PREPAID_SESSIONS_COLUMN, ACTIONS_COLUMN],
+      [],
+    )
+
+    const cellProps = useMemo<PagingTableProps<Member>['cellProps']>(() => {
+      return ({ column, row }: Cell<Member & { empty?: boolean }, unknown>) => {
+        const props: TdProps = { verticalAlign: 'middle' }
+
+        if (row.original.empty) {
+          if (column.columnDef.header === 'Name') {
+            props.colSpan = 5
+            props.textAlign = 'center'
+            props.color = 'muted'
+            props.h = '3xs'
+          } else {
+            props.display = 'none'
+          }
+        }
+
+        if (column.columnDef.header === 'Actions') {
+          props.py = 2
+        }
+
+        return props
+      }
+    }, [])
+
+    assignRef(filterRef, (value: string) => {
+      dispatch({ type: 'SET_FILTER', payload: value })
+    })
+
+    assignRef(perPageRef, (value: number) => {
+      dispatch({ type: 'SET_PAGE_SIZE', payload: value })
+    })
+
+    assignRef(currentPageRef, (value: number) => {
+      dispatch({ type: 'SET_PAGE', payload: value })
+    })
+
+    const hasData = !!paginatedMembers.length
+
+    useEffect(() => {
+      if (hasData) {
+        onTotalPageChange(totalPages)
+      }
+    }, [hasData, totalPages, onTotalPageChange])
+
+    const resolvedData = hasData
+      ? paginatedMembers
+      : [
+          {
+            id: '',
+            name: 'No members found',
+            email: '',
+            prepaidSessions: 0,
+            empty: true,
+          },
+        ]
+
+    if (isLoading) {
+      return <SkeletonTable />
+    }
+
+    return (
+      <Table<Member & { empty?: boolean }>
+        sx={{ 'tbody > tr:last-of-type > td': { borderBottomWidth: '0px' } }}
+        borderCollapse="separate"
+        borderWidth="1px"
+        columns={columns}
+        data={resolvedData}
+        rowId="id"
+        cellProps={cellProps}
+        highlightOnHover={hasData}
+        highlightOnSelected={hasData}
+        rowsClickSelect={hasData}
+        rounded="md"
+      />
+    )
+  },
+)
 
 MemberManagementTable.displayName = 'MemberManagementTable'

--- a/src/components/admin/members/MemberManagementTable/TablePagination.tsx
+++ b/src/components/admin/members/MemberManagementTable/TablePagination.tsx
@@ -1,0 +1,53 @@
+import type { FC, RefObject } from 'react'
+import { memo, useCallback, useState } from 'react'
+import { Grid, GridItem, Pagination, Select, Option, assignRef } from '@yamada-ui/react'
+
+interface TableProps {
+  totalPageRef: RefObject<(value: number) => void>
+  onPerPageChange: (value: number) => void
+  onPageChange: (page: number) => void
+}
+
+export const TablePagination: FC<TableProps> = memo(
+  ({ totalPageRef, onPerPageChange, onPageChange }) => {
+    const [pages, setPages] = useState(1)
+    const [currentPage, setCurrentPage] = useState(1)
+
+    const handlePageChange = useCallback(
+      (page: number) => {
+        setCurrentPage(page)
+        onPageChange(page)
+      },
+      [onPageChange],
+    )
+
+    const handlePerPageChange = useCallback(
+      (value: string) => {
+        handlePageChange(1)
+        onPerPageChange(Number.parseInt(value))
+      },
+      [handlePageChange, onPerPageChange],
+    )
+
+    assignRef(totalPageRef, setPages)
+
+    return (
+      <Grid gridTemplateColumns="repeat(3, 1fr)" gap="md" placeItems="center">
+        <GridItem />
+        <GridItem>
+          <Pagination page={currentPage} total={pages} onChange={handlePageChange} withEdges />
+        </GridItem>
+        <GridItem>
+          <Select onChange={handlePerPageChange} defaultValue="20" w="32">
+            <Option value="10">10</Option>
+            <Option value="20">20</Option>
+            <Option value="50">50</Option>
+            <Option value="100">100</Option>
+          </Select>
+        </GridItem>
+      </Grid>
+    )
+  },
+)
+
+TablePagination.displayName = 'TablePagination'

--- a/src/components/admin/members/MemberManagementTable/index.tsx
+++ b/src/components/admin/members/MemberManagementTable/index.tsx
@@ -2,17 +2,16 @@
 
 import { memo, useRef } from 'react'
 import { noop } from '@yamada-ui/react'
-import { MemberManagementTable } from './Table'
 import { Filter } from './Filter'
+import { PagingTable } from './PagingTable'
 
 export const Members = memo(() => {
   const filterRef = useRef<(value: string) => void>(noop)
-  const resetFilterRef = useRef<() => void>(noop)
 
   return (
     <>
-      <Filter filterRef={filterRef} resetRef={resetFilterRef} />
-      <MemberManagementTable filterRef={filterRef} />
+      <Filter filterRef={filterRef} />
+      <PagingTable filterRef={filterRef} />
     </>
   )
 })

--- a/src/hooks/query/useMembers.ts
+++ b/src/hooks/query/useMembers.ts
@@ -10,6 +10,43 @@ export type MemberResponse = {
   prepaidSessions: number
 }
 
+const MOCK_MEMBERS: MemberResponse[] = Array.from({ length: 100 }, (_, i) => {
+  const id = (i + 1).toString()
+  const firstNames = [
+    'John',
+    'Jane',
+    'Mike',
+    'Sarah',
+    'Tom',
+    'Emily',
+    'David',
+    'Lisa',
+    'James',
+    'Emma',
+  ]
+  const lastNames = [
+    'Smith',
+    'Johnson',
+    'Williams',
+    'Brown',
+    'Jones',
+    'Garcia',
+    'Miller',
+    'Davis',
+    'Rodriguez',
+    'Martinez',
+  ]
+  const firstName = firstNames[Math.floor(Math.random() * firstNames.length)]
+  const lastName = lastNames[Math.floor(Math.random() * lastNames.length)]
+  return {
+    id,
+    firstName,
+    lastName,
+    email: `${firstName.toLowerCase()}.${lastName.toLowerCase()}${id}@example.com`,
+    prepaidSessions: Math.floor(Math.random() * 20) + 1,
+  }
+})
+
 const fetchMembers = async (): Promise<MemberResponse[]> => {
   const response = await fetch(`/api/users?member=true&verified=true`, {
     cache: 'no-store',
@@ -20,7 +57,7 @@ const fetchMembers = async (): Promise<MemberResponse[]> => {
 export const useMembers = () => {
   const query = useQuery({
     queryKey: [QUERY_KEY.MEMBERS],
-    queryFn: fetchMembers,
+    queryFn: () => MOCK_MEMBERS,
   })
 
   return query

--- a/src/hooks/query/useMembers.ts
+++ b/src/hooks/query/useMembers.ts
@@ -10,43 +10,6 @@ export type MemberResponse = {
   prepaidSessions: number
 }
 
-const MOCK_MEMBERS: MemberResponse[] = Array.from({ length: 100 }, (_, i) => {
-  const id = (i + 1).toString()
-  const firstNames = [
-    'John',
-    'Jane',
-    'Mike',
-    'Sarah',
-    'Tom',
-    'Emily',
-    'David',
-    'Lisa',
-    'James',
-    'Emma',
-  ]
-  const lastNames = [
-    'Smith',
-    'Johnson',
-    'Williams',
-    'Brown',
-    'Jones',
-    'Garcia',
-    'Miller',
-    'Davis',
-    'Rodriguez',
-    'Martinez',
-  ]
-  const firstName = firstNames[Math.floor(Math.random() * firstNames.length)]
-  const lastName = lastNames[Math.floor(Math.random() * lastNames.length)]
-  return {
-    id,
-    firstName,
-    lastName,
-    email: `${firstName.toLowerCase()}.${lastName.toLowerCase()}${id}@example.com`,
-    prepaidSessions: Math.floor(Math.random() * 20) + 1,
-  }
-})
-
 const fetchMembers = async (): Promise<MemberResponse[]> => {
   const response = await fetch(`/api/users?member=true&verified=true`, {
     cache: 'no-store',
@@ -57,7 +20,7 @@ const fetchMembers = async (): Promise<MemberResponse[]> => {
 export const useMembers = () => {
   const query = useQuery({
     queryKey: [QUERY_KEY.MEMBERS],
-    queryFn: () => MOCK_MEMBERS,
+    queryFn: () => fetchMembers(),
   })
 
   return query


### PR DESCRIPTION
This potentially improves the overall performance on the `/admin/members` page.

# Description

I have refactored the member management table which prevents the pagination from being re-rendered on filter input.

https://github.com/user-attachments/assets/0999bfdc-e82b-4809-b4a8-eeec0d991a4f


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)
- [ ] Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added thorough tests that prove my fix is effective and that my feature works
- [x] I've requested a review from another user
