### PR TITLE
feat: implement auth logic in frontend

### DIFF
--- a/src/app/api/auth/google/callback/route.ts
+++ b/src/app/api/auth/google/callback/route.ts
@@ -8,6 +8,7 @@ import { UserInfoResponse, UserInfoResponseSchema } from '@/types/auth'
 import { MembershipType } from '@/types/types'
 
 import jwt from 'jsonwebtoken'
+import { redirect } from 'next/navigation'
 
 export const GET = async (req: NextRequest) => {
   const params = req.nextUrl.searchParams
@@ -85,14 +86,12 @@ export const GET = async (req: NextRequest) => {
     { expiresIn: '1h' },
   )
 
-  const response = NextResponse.json({ token })
-
-  response.cookies.set('auth_token', token, {
+  cookieStore.set('auth_token', token, {
     httpOnly: true,
     secure: process.env.NODE_ENV === 'production',
     sameSite: 'strict',
     maxAge: 60 * 60,
   })
 
-  return response
+  return redirect('/onboarding/name')
 }

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -25,7 +25,7 @@ export const UserSchema = z.object({
   firstName: z.string(),
   lastName: z.string(),
   email: z.string().email(),
-  role: z.enum(Object.values(MembershipType) as [string, ...string[]]),
+  role: z.nativeEnum(MembershipType),
   remainingSessions: z.number().nullable().optional(),
   image: z.union([z.string(), MediaSchema]).nullable().optional(),
   updatedAt: z.string(),


### PR DESCRIPTION
# Description
Added functionality to `useCurrentUser` HOC but has not been implemented yet, as well as rewriting `api/auth/google/callback` to redirect to the onboarding instead of returning the JWT token as this is unnecessary since it is already being saved to cookies (the test for this route has also been rewritten). I also wrote a utility `AuthToken` class for reusability. 

Fixes #106 

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [ ] Manual testing (requires screenshots or videos)
- [x] Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added thorough tests that prove my fix is effective and that my feature works
- [x] I've requested a review from another user
