### PR TITLE
Enable remote caching on fly deployment

### DIFF
--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set Backend Secrets
         id: backend-secrets
         run: >
-          flyctl secrets set --config apps/backend/fly.staging.backend.toml
+          flyctl secrets set --config apps/backend/fly.staging.toml
           DATABASE_URI=${{ secrets.DATABASE_URI }}
           JWT_SECRET=${{ secrets.JWT_SECRET }}
           PAYLOAD_SECRET=${{ secrets.PAYLOAD_SECRET }}
@@ -45,12 +45,12 @@ jobs:
 
       - name: Deploy Backend Secrets
         id: backend-secrets-deploy
-        run: flyctl secrets deploy --config apps/backend/fly.staging.backend.toml
+        run: flyctl secrets deploy --config apps/backend/fly.staging.toml
 
       - name: Deploy Backend
         id: deploy-backend
         run: >
-          flyctl deploy --remote-only --config apps/backend/fly.staging.backend.toml
+          flyctl deploy --remote-only --config apps/backend/fly.staging.toml
           --build-arg DATABASE_URI="${{ secrets.DATABASE_URI }}"
           --build-arg JWT_SECRET="${{ secrets.JWT_SECRET }}"
           --build-arg PAYLOAD_SECRET="${{ secrets.PAYLOAD_SECRET }}"
@@ -77,7 +77,7 @@ jobs:
       - name: Set Frontend Secrets
         id: frontend-secrets
         run: >
-          flyctl secrets set --config apps/frontend/fly.staging.frontend.toml
+          flyctl secrets set --config apps/frontend/fly.staging.toml
           NEXT_PUBLIC_API_URL=${{ secrets.NEXT_PUBLIC_API_URL }}
           NEXT_PUBLIC_URL=${{ secrets.NEXT_PUBLIC_URL }}
           JWT_SECRET=${{ secrets.JWT_SECRET }}
@@ -86,12 +86,12 @@ jobs:
 
       - name: Deploy Frontend Secrets
         id: frontend-secrets-deploy
-        run: flyctl secrets deploy --config apps/frontend/fly.staging.frontend.toml
+        run: flyctl secrets deploy --config apps/frontend/fly.staging.toml
 
       - name: Deploy Frontend
         id: deploy-frontend
         run: >
-          flyctl deploy --remote-only --config apps/frontend/fly.staging.frontend.toml
+          flyctl deploy --remote-only --config apps/frontend/fly.staging.toml
           --build-arg NEXT_PUBLIC_API_URL="${{ secrets.NEXT_PUBLIC_API_URL }}"
           --build-arg NEXT_PUBLIC_URL="${{ secrets.NEXT_PUBLIC_URL }}"
           --build-arg JWT_SECRET="${{ secrets.JWT_SECRET }}"

--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -30,25 +30,36 @@ jobs:
 
       - name: Set Backend Secrets
         id: backend-secrets
-        run: flyctl secrets set --config fly.staging.backend.toml DATABASE_URI=${{ secrets.DATABASE_URI }} JWT_SECRET=${{ secrets.JWT_SECRET }} PAYLOAD_SECRET=${{ secrets.PAYLOAD_SECRET }} GOOGLE_CLIENT_ID=${{ secrets.GOOGLE_CLIENT_ID }} GOOGLE_CLIENT_SECRET=${{ secrets.GOOGLE_CLIENT_SECRET }} NEXT_PUBLIC_URL=${{ secrets.NEXT_PUBLIC_URL }} TURBO_TEAM=${{ vars.TURBO_TEAM }} TURBO_TOKEN=${{ secrets.TURBO_TOKEN }} NEXT_PUBLIC_URL=${{ secrets.NEXT_PUBLIC_URL }} NEXT_PUBLIC_API_URL=${{ secrets.NEXT_PUBLIC_API_URL }}
+        run: >
+          flyctl secrets set --config apps/backend/fly.staging.backend.toml
+          DATABASE_URI=${{ secrets.DATABASE_URI }}
+          JWT_SECRET=${{ secrets.JWT_SECRET }}
+          PAYLOAD_SECRET=${{ secrets.PAYLOAD_SECRET }}
+          GOOGLE_CLIENT_ID=${{ secrets.GOOGLE_CLIENT_ID }}
+          GOOGLE_CLIENT_SECRET=${{ secrets.GOOGLE_CLIENT_SECRET }}
+          NEXT_PUBLIC_URL=${{ secrets.NEXT_PUBLIC_URL }}
+          TURBO_TEAM=${{ vars.TURBO_TEAM }}
+          TURBO_TOKEN=${{ secrets.TURBO_TOKEN }}
+          NEXT_PUBLIC_URL=${{ secrets.NEXT_PUBLIC_URL }}
+          NEXT_PUBLIC_API_URL=${{ secrets.NEXT_PUBLIC_API_URL }}
 
       - name: Deploy Backend Secrets
         id: backend-secrets-deploy
-        run: flyctl secrets deploy --config fly.staging.backend.toml
+        run: flyctl secrets deploy --config apps/backend/fly.staging.backend.toml
 
       - name: Deploy Backend
         id: deploy-backend
         run: >
-          flyctl deploy --remote-only --config fly.staging.backend.toml
-          --build-secret DATABASE_URI="${{ secrets.DATABASE_URI }}"
-          --build-secret JWT_SECRET="${{ secrets.JWT_SECRET }}"
-          --build-secret PAYLOAD_SECRET="${{ secrets.PAYLOAD_SECRET }}"
-          --build-secret GOOGLE_CLIENT_ID="${{ secrets.GOOGLE_CLIENT_ID }}"
-          --build-secret GOOGLE_CLIENT_SECRET="${{ secrets.GOOGLE_CLIENT_SECRET }}"
-          --build-secret NEXT_PUBLIC_URL="${{ secrets.NEXT_PUBLIC_URL }}"
-          --build-secret TURBO_TEAM="${{ vars.TURBO_TEAM }}"
-          --build-secret TURBO_TOKEN="${{ secrets.TURBO_TOKEN }}"
-          --build-secret NEXT_PUBLIC_API_URL="${{ secrets.NEXT_PUBLIC_API_URL }}"
+          flyctl deploy --remote-only --config apps/backend/fly.staging.backend.toml
+          --build-arg DATABASE_URI="${{ secrets.DATABASE_URI }}"
+          --build-arg JWT_SECRET="${{ secrets.JWT_SECRET }}"
+          --build-arg PAYLOAD_SECRET="${{ secrets.PAYLOAD_SECRET }}"
+          --build-arg GOOGLE_CLIENT_ID="${{ secrets.GOOGLE_CLIENT_ID }}"
+          --build-arg GOOGLE_CLIENT_SECRET="${{ secrets.GOOGLE_CLIENT_SECRET }}"
+          --build-arg NEXT_PUBLIC_URL="${{ secrets.NEXT_PUBLIC_URL }}"
+          --build-arg TURBO_TEAM="${{ vars.TURBO_TEAM }}"
+          --build-arg TURBO_TOKEN="${{ secrets.TURBO_TOKEN }}"
+          --build-arg NEXT_PUBLIC_API_URL="${{ secrets.NEXT_PUBLIC_API_URL }}"
 
   deploy-frontend:
     name: Deploy Frontend
@@ -65,21 +76,27 @@ jobs:
 
       - name: Set Frontend Secrets
         id: frontend-secrets
-        run: flyctl secrets set --config fly.staging.frontend.toml NEXT_PUBLIC_API_URL=${{ secrets.NEXT_PUBLIC_API_URL }} NEXT_PUBLIC_URL=${{ secrets.NEXT_PUBLIC_URL }} JWT_SECRET=${{ secrets.JWT_SECRET }} TURBO_TEAM=${{ vars.TURBO_TEAM }} TURBO_TOKEN=${{ secrets.TURBO_TOKEN }}
+        run: >
+          flyctl secrets set --config apps/frontend/fly.staging.frontend.toml
+          NEXT_PUBLIC_API_URL=${{ secrets.NEXT_PUBLIC_API_URL }}
+          NEXT_PUBLIC_URL=${{ secrets.NEXT_PUBLIC_URL }}
+          JWT_SECRET=${{ secrets.JWT_SECRET }}
+          TURBO_TEAM=${{ vars.TURBO_TEAM }}
+          TURBO_TOKEN=${{ secrets.TURBO_TOKEN }}
 
       - name: Deploy Frontend Secrets
         id: frontend-secrets-deploy
-        run: flyctl secrets deploy --config fly.staging.frontend.toml
+        run: flyctl secrets deploy --config apps/frontend/fly.staging.frontend.toml
 
       - name: Deploy Frontend
         id: deploy-frontend
         run: >
-          flyctl deploy --remote-only --config fly.staging.frontend.toml
-          --build-secret NEXT_PUBLIC_API_URL="${{ secrets.NEXT_PUBLIC_API_URL }}"
-          --build-secret NEXT_PUBLIC_URL="${{ secrets.NEXT_PUBLIC_URL }}"
-          --build-secret JWT_SECRET="${{ secrets.JWT_SECRET }}"
-          --build-secret TURBO_TEAM="${{ vars.TURBO_TEAM }}"
-          --build-secret TURBO_TOKEN="${{ secrets.TURBO_TOKEN }}"
+          flyctl deploy --remote-only --config apps/frontend/fly.staging.frontend.toml
+          --build-arg NEXT_PUBLIC_API_URL="${{ secrets.NEXT_PUBLIC_API_URL }}"
+          --build-arg NEXT_PUBLIC_URL="${{ secrets.NEXT_PUBLIC_URL }}"
+          --build-arg JWT_SECRET="${{ secrets.JWT_SECRET }}"
+          --build-arg TURBO_TEAM="${{ vars.TURBO_TEAM }}"
+          --build-arg TURBO_TOKEN="${{ secrets.TURBO_TOKEN }}"
 
   deploy-to-production:
     name: Deploy UABC Production App

--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -32,27 +32,23 @@ RUN pnpm install --frozen-lockfile
 COPY --from=builder /app/out/full/ .
 COPY turbo.json turbo.json
 
-# Mount build secrets
-RUN --mount=type=secret,id=DATABASE_URI \
-    --mount=type=secret,id=JWT_SECRET \
-    --mount=type=secret,id=PAYLOAD_SECRET \
-    --mount=type=secret,id=GOOGLE_CLIENT_ID \
-    --mount=type=secret,id=GOOGLE_CLIENT_SECRET \
-    --mount=type=secret,id=NEXT_PUBLIC_URL \
-    --mount=type=secret,id=TURBO_TEAM \
-    --mount=type=secret,id=TURBO_TOKEN \
-    --mount=type=secret,id=NEXT_PUBLIC_API_URL \
-    echo "DATABASE_URI=$(cat /run/secrets/DATABASE_URI)" >> apps/backend/.env && \
-    echo "JWT_SECRET=$(cat /run/secrets/JWT_SECRET)" >> apps/backend/.env && \
-    echo "PAYLOAD_SECRET=$(cat /run/secrets/PAYLOAD_SECRET)" >> apps/backend/.env && \
-    echo "GOOGLE_CLIENT_ID=$(cat /run/secrets/GOOGLE_CLIENT_ID)" >> apps/backend/.env && \
-    echo "GOOGLE_CLIENT_SECRET=$(cat /run/secrets/GOOGLE_CLIENT_SECRET)" >> apps/backend/.env && \
-    echo "NEXT_PUBLIC_URL=$(cat /run/secrets/NEXT_PUBLIC_URL)" >> apps/backend/.env && \
-    echo "TURBO_TEAM=$(cat /run/secrets/TURBO_TEAM)" >> .env && \
-    echo "TURBO_TOKEN=$(cat /run/secrets/TURBO_TOKEN)" >> .env && \
-    echo "NEXT_PUBLIC_API_URL=$(cat /run/secrets/NEXT_PUBLIC_API_URL)" >> apps/backend/.env && \
-    export TURBO_TEAM=$(cat /run/secrets/TURBO_TEAM) && \
-    export TURBO_TOKEN=$(cat /run/secrets/TURBO_TOKEN)
+ARG DATABASE_URI
+ARG JWT_SECRET
+ARG PAYLOAD_SECRET
+ARG GOOGLE_CLIENT_ID
+ARG GOOGLE_CLIENT_SECRET
+ARG NEXT_PUBLIC_URL
+ARG NEXT_PUBLIC_API_URL
+ARG TURBO_TEAM
+ARG TURBO_TOKEN
+
+ENV DATABASE_URI=${DATABASE_URI}
+ENV JWT_SECRET=${JWT_SECRET}
+ENV PAYLOAD_SECRET=${PAYLOAD_SECRET}
+ENV GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}
+ENV GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET}
+ENV NEXT_PUBLIC_URL=${NEXT_PUBLIC_URL}
+ENV NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
 
 # Now run the build
 RUN pnpm build --filter backend

--- a/apps/backend/fly.staging.toml
+++ b/apps/backend/fly.staging.toml
@@ -3,7 +3,7 @@ primary_region = 'syd'
 
 [build]
   context = "."
-  dockerfile = "apps/backend/Dockerfile"
+  dockerfile = "Dockerfile"
 
 [http_service]
   internal_port = 3000
@@ -15,4 +15,4 @@ primary_region = 'syd'
 [[vm]]
   cpu_kind = 'shared'
   cpus = 1
-  memory_mb = 512
+  memory_mb = 1024

--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -32,19 +32,17 @@ RUN pnpm install --frozen-lockfile
 COPY --from=builder /app/out/full/ .
 COPY turbo.json turbo.json
 
-# Mount build secrets
-RUN --mount=type=secret,id=NEXT_PUBLIC_URL \
-    --mount=type=secret,id=NEXT_PUBLIC_API_URL \
-    --mount=type=secret,id=JWT_SECRET \
-    --mount=type=secret,id=TURBO_TEAM \
-    --mount=type=secret,id=TURBO_TOKEN \
-    echo "NEXT_PUBLIC_URL=$(cat /run/secrets/NEXT_PUBLIC_URL)" >> apps/frontend/.env && \
-    echo "NEXT_PUBLIC_API_URL=$(cat /run/secrets/NEXT_PUBLIC_API_URL)" >> apps/frontend/.env && \
-    echo "JWT_SECRET=$(cat /run/secrets/JWT_SECRET)" >> apps/frontend/.env && \
-    echo "TURBO_TEAM=$(cat /run/secrets/TURBO_TEAM)" >> .env && \
-    echo "TURBO_TOKEN=$(cat /run/secrets/TURBO_TOKEN)" >> .env && \
-    export TURBO_TEAM=$(cat /run/secrets/TURBO_TEAM) && \
-    export TURBO_TOKEN=$(cat /run/secrets/TURBO_TOKEN)
+ARG NEXT_PUBLIC_URL
+ARG NEXT_PUBLIC_API_URL
+ARG JWT_SECRET
+ARG TURBO_TEAM
+ARG TURBO_TOKEN
+
+ENV NEXT_PUBLIC_URL=${NEXT_PUBLIC_URL}
+ENV NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
+ENV JWT_SECRET=${JWT_SECRET}
+ENV TURBO_TEAM=${TURBO_TEAM}
+ENV TURBO_TOKEN=${TURBO_TOKEN}
 
 RUN pnpm build --filter frontend
 

--- a/apps/frontend/fly.staging.toml
+++ b/apps/frontend/fly.staging.toml
@@ -3,7 +3,7 @@ primary_region = 'syd'
 
 [build]
   context = "."
-  dockerfile = "apps/frontend/Dockerfile"
+  dockerfile = "Dockerfile"
 
 [http_service]
   internal_port = 3001
@@ -15,4 +15,4 @@ primary_region = 'syd'
 [[vm]]
   cpu_kind = 'shared'
   cpus = 1
-  memory_mb = 512
+  memory_mb = 1024


### PR DESCRIPTION
# Description

I have found a way to enable remote caching on fly deployment, and when I ran them locally on my terminal, it did say remote caching is enabled, but I am not sure if it will actually hit the cache.

Closes #127

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [ ] Manual testing (requires screenshots or videos)
- [ ] Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added thorough tests that prove my fix is effective and that my feature works
- [ ] I've requested a review from another user
