### PR TITLE
140 backend set vitest setup to clear all collections

### DIFF
--- a/apps/backend/src/collections/services/AuthService.test.ts
+++ b/apps/backend/src/collections/services/AuthService.test.ts
@@ -1,4 +1,4 @@
-import { clearCollection, testPayloadObject } from "@/test-config/backend-utils"
+import { payload } from "@/data-layer/adapters/Payload"
 import { authenticationCreateMock } from "@/test-config/mocks/Authentication.mock"
 import { userMock } from "@/test-config/mocks/User.mock"
 import dotenv from "dotenv"
@@ -9,19 +9,15 @@ dotenv.config()
 const authService = new AuthService()
 
 describe("auth service", () => {
-  afterEach(async () => {
-    await clearCollection(testPayloadObject, "authentication")
-  })
-
   it("should create an authentication document", async () => {
     // Create user first so that the auth mock will have an existent user
-    await testPayloadObject.create({
+    await payload.create({
       collection: "user",
       data: userMock,
     })
 
     const newAuth = await authService.createAuth(authenticationCreateMock)
-    const fetchedAuth = await testPayloadObject.find({
+    const fetchedAuth = await payload.find({
       collection: "authentication",
       where: {
         id: {

--- a/apps/backend/src/collections/services/AuthService.ts
+++ b/apps/backend/src/collections/services/AuthService.ts
@@ -1,11 +1,6 @@
+import { payload } from "@/data-layer/adapters/Payload"
 import type { Authentication } from "@/payload-types"
 import type { CreateAuthenticationData } from "@/types/collections"
-import configPromise from "@payload-config"
-import { getPayload } from "payload"
-
-const payload = await getPayload({
-  config: configPromise,
-})
 
 export default class AuthService {
   /**

--- a/apps/backend/src/collections/services/UserService.test.ts
+++ b/apps/backend/src/collections/services/UserService.test.ts
@@ -1,4 +1,4 @@
-import { clearCollection, testPayloadObject } from "@/test-config/backend-utils"
+import { testPayloadObject } from "@/test-config/backend-utils"
 import { userCreateMock } from "@/test-config/mocks/User.mock"
 import dotenv from "dotenv"
 import UserService from "./UserService"
@@ -8,10 +8,6 @@ dotenv.config()
 const userService = new UserService()
 
 describe("user service", () => {
-  afterEach(async () => {
-    await clearCollection(testPayloadObject, "user")
-  })
-
   it("should create a user document", async () => {
     const newUser = await userService.createUser(userCreateMock)
     const fetchedUser = await testPayloadObject.find({

--- a/apps/backend/src/collections/services/UserService.ts
+++ b/apps/backend/src/collections/services/UserService.ts
@@ -1,11 +1,6 @@
+import { payload } from "@/data-layer/adapters/Payload"
 import type { User } from "@/payload-types"
 import type { CreateUserData } from "@/types/collections"
-import configPromise from "@payload-config"
-import { getPayload } from "payload"
-
-const payload = await getPayload({
-  config: configPromise,
-})
 
 export default class UserService {
   /**

--- a/apps/backend/src/test-config/vitest.setup.ts
+++ b/apps/backend/src/test-config/vitest.setup.ts
@@ -1,0 +1,10 @@
+import type { CollectionSlug } from "payload"
+
+import { payload } from "@/data-layer/adapters/Payload"
+import { clearCollection } from "./backend-utils"
+
+afterEach(async () => {
+  for (const slug of Object.keys(payload.collections)) {
+    await clearCollection(payload, slug as CollectionSlug)
+  }
+})

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -19,6 +19,7 @@ export default defineConfig({
       "dotenv/config",
       "@repo/test-config/src/mongodb-setup.ts",
       "@repo/test-config/src/dom-setup.ts",
+      "/src/test-config/vitest.setup.ts",
     ],
     globals: true,
     /**


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes towards the related issue. Please also  include relevant context. List any dependencies that are required for this change. -->

Vastly aimed at refactoring and improving our current test repo, seems like the recent turborepo setup cancelled my commits. 

Changes:
- Removed the need for clearing individual collections, the setup now clears all tests `afterEach`
- Removed clear collections in all tests
- Fixed the use of the testPayloadObject as the `payload` adapter already uses this whenever the env is in test mode

Fixes #140 

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added thorough tests that prove my fix is effective and that my feature works
- [ ] I've requested a review from another user
