### PR TITLE
fix(renovate): update token to use `PAT_TOKEN` to allow workflows to run in renovate pr

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Run Renovate
         uses: renovatebot/github-action@v42.0.2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RENOVATE_TOKEN }}
           configurationFile: renovate.json
         env:
           RENOVATE_REPOSITORY_CACHE: ${{ github.event.inputs.repoCache }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Run Renovate
         uses: renovatebot/github-action@v42.0.2
         with:
-          token: ${{ secrets.RENOVATE_TOKEN }}
+          token: ${{ secrets.PAT_TOKEN }}
           configurationFile: renovate.json
         env:
           RENOVATE_REPOSITORY_CACHE: ${{ github.event.inputs.repoCache }}


### PR DESCRIPTION
# Description

I have replaced `GITHUB_TOKEN` with `PAT_TOKEN`.
> [!IMPORTANT]
> We need to set a PAT token `PAT_TOKEN` in secrets.

We need to do this because using normal `secrets.GITHUB_TOKEN` prevents CI from running to prevent malicious workflows or recursive workflow.

https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow 

Closes #192

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [ ] Manual testing (requires screenshots or videos)
- [ ] Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added thorough tests that prove my fix is effective and that my feature works
- [ ] I've requested a review from another user
