### PR TITLE
fix(ci-pipeline): run install if cache misses

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -110,6 +110,7 @@ jobs:
 
       - name: Restore Turborepo cache
         uses: actions/cache@v4
+        id: cache
         with:
           path: |
             .turbo
@@ -120,6 +121,10 @@ jobs:
           key: ${{ runner.os }}-turbo-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-turbo-
+
+      - name: Install dependencies if cache is not hit
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: pnpm install --frozen-lockfile
 
       - name: Check formatting
         run: pnpm biome check .
@@ -151,6 +156,7 @@ jobs:
 
       - name: Restore Turborepo cache
         uses: actions/cache@v4
+        id: cache
         with:
           path: |
             .turbo
@@ -161,6 +167,10 @@ jobs:
           key: ${{ runner.os }}-turbo-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-turbo-
+
+      - name: Install dependencies if cache is not hit
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: pnpm install --frozen-lockfile
 
       - name: Build
         run: pnpm turbo run build
@@ -189,6 +199,7 @@ jobs:
 
       - name: Restore Turborepo cache
         uses: actions/cache@v4
+        id: cache
         with:
           path: |
             .turbo
@@ -199,6 +210,10 @@ jobs:
           key: ${{ runner.os }}-turbo-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-turbo-
+
+      - name: Install dependencies if cache is not hit
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: pnpm install --frozen-lockfile
 
       - name: Type Check
         run: pnpm turbo run check-types
@@ -229,6 +244,7 @@ jobs:
 
       - name: Restore Turborepo cache
         uses: actions/cache@v4
+        id: cache
         with:
           path: |
             .turbo
@@ -239,6 +255,10 @@ jobs:
           key: ${{ runner.os }}-turbo-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-turbo-
+
+      - name: Install dependencies if cache is not hit
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: pnpm install --frozen-lockfile
 
       - name: Test with Coverage
         run: |
@@ -290,6 +310,7 @@ jobs:
 
       - name: Restore Turborepo cache
         uses: actions/cache@v4
+        id: cache
         with:
           path: |
             .turbo
@@ -300,6 +321,10 @@ jobs:
           key: ${{ runner.os }}-turbo-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-turbo-
+
+      - name: Install dependencies if cache is not hit
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: pnpm install --frozen-lockfile
 
       - name: Generate typing
         run: pnpm turbo run generate:types


### PR DESCRIPTION
# Description

Since we are currently having issues with cache, I made it so it will run pnpm install if cache misses.

> [!NOTE]
>  In future, we should separate turbo and node_modules cache and only restore the node_modules cache in the quality check steps.

Closes #297

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [ ] Manual testing (requires screenshots or videos)
- [ ] Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added thorough tests that prove my fix is effective and that my feature works
- [x] I've requested a review from another user
