### PR TITLE
feat(loading-state-bar): add loading state bar primitive component

### DIFF
--- a/packages/ui/src/components/Primitive/LoadingStateBar/LoadingStateBar.stories.tsx
+++ b/packages/ui/src/components/Primitive/LoadingStateBar/LoadingStateBar.stories.tsx
@@ -1,0 +1,171 @@
+import { SEMANTIC_COLOR_SCHEMES } from "@repo/theme/semantics"
+import type { Meta, StoryObj } from "@storybook/nextjs"
+import { PropsTable } from "@storybook-config/components"
+import { LoadingStateBar } from "./LoadingStateBar"
+
+const meta: Meta<typeof LoadingStateBar> = {
+  title: "Primitive Components / LoadingStateBar",
+  component: LoadingStateBar,
+  argTypes: {
+    value: {
+      control: { type: "range", min: 0, max: 100, step: 1 },
+      description: "The value of the progress (0-100)",
+    },
+    colorScheme: {
+      control: "text",
+      description: "Custom color for the progress bar",
+    },
+    disabled: {
+      control: "boolean",
+      description: "Whether the loading bar is disabled",
+    },
+    size: {
+      control: "select",
+      options: ["xs", "sm", "md", "lg"],
+      description: "Size of the progress bar",
+    },
+    max: {
+      control: "number",
+      description: "Maximum value for the progress",
+    },
+    min: {
+      control: "number",
+      description: "Minimum value for the progress",
+    },
+    hasStripe: {
+      control: "boolean",
+      description: "If true, the progress bar will show stripe",
+    },
+    isStripeAnimation: {
+      control: "boolean",
+      description: "If true, and hasStripe is true, the stripes will be animated",
+    },
+    isAnimation: {
+      control: "boolean",
+      description: "If true, the progress will be indeterminate and the value prop will be ignored",
+    },
+    speed: {
+      control: "text",
+      description: "The animation speed in seconds",
+    },
+  },
+  args: {
+    value: 45,
+    colorScheme: "primary",
+    disabled: false,
+    size: "md",
+    max: 100,
+    min: 0,
+    hasStripe: false,
+    isStripeAnimation: false,
+    isAnimation: false,
+    speed: "1.4s",
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof LoadingStateBar>
+
+export const Default: Story = {
+  args: {
+    value: 45,
+  },
+}
+
+export const DisabledState: Story = {
+  args: {
+    value: 30,
+    disabled: true,
+  },
+}
+
+export const StripedVariant: Story = {
+  args: {
+    value: 65,
+    hasStripe: true,
+    colorScheme: "primary",
+  },
+}
+
+export const SpeedVariations: Story = {
+  render: (args) => {
+    const speeds = ["0.5s", "1s", "1.4s", "2s", "3s"]
+    const animationTypes = [
+      { label: "Stripe Animation", hasStripe: true, isStripeAnimation: true },
+      { label: "Indeterminate", isAnimation: true },
+    ]
+
+    return (
+      <PropsTable columns={speeds} rows={animationTypes.map((type) => type.label)}>
+        {(column, row, key) => {
+          const animationType = animationTypes.find((type) => type.label === row)
+          return (
+            <LoadingStateBar {...args} {...animationType} key={key} speed={column} value={60} />
+          )
+        }}
+      </PropsTable>
+    )
+  },
+}
+
+export const AnimationTypes: Story = {
+  render: (args) => {
+    const animationStates = [
+      { label: "Static", value: 50 },
+      { label: "With Stripes", value: 50, hasStripe: true },
+      { label: "Animated Stripes", value: 50, hasStripe: true, isStripeAnimation: true },
+      { label: "Indeterminate", isAnimation: true },
+    ]
+
+    return (
+      <PropsTable
+        columns={SEMANTIC_COLOR_SCHEMES}
+        rows={animationStates.map((state) => state.label)}
+      >
+        {(column, row, key) => {
+          const animationState = animationStates.find((state) => state.label === row)
+          return <LoadingStateBar {...args} {...animationState} colorScheme={column} key={key} />
+        }}
+      </PropsTable>
+    )
+  },
+}
+
+export const ColorVariations: Story = {
+  render: (args) => {
+    const states = ["normal", "disabled"]
+
+    return (
+      <PropsTable columns={states} rows={SEMANTIC_COLOR_SCHEMES}>
+        {(column, row, key) => {
+          const isDisabled = column === "disabled"
+          return (
+            <LoadingStateBar
+              {...args}
+              colorScheme={row}
+              disabled={isDisabled}
+              key={key}
+              value={isDisabled ? 30 : 65}
+            />
+          )
+        }}
+      </PropsTable>
+    )
+  },
+}
+
+export const SizeVariations: Story = {
+  render: (args) => {
+    const sizes = ["xs", "sm", "md", "lg"]
+    const values = [25, 50, 75, 100]
+
+    return (
+      <PropsTable columns={values.map((v) => `${v}%`)} rows={sizes}>
+        {(column, row, key) => {
+          const value = Number.parseInt(column.replace("%", ""))
+          return <LoadingStateBar {...args} key={key} size={row} value={value} />
+        }}
+      </PropsTable>
+    )
+  },
+}

--- a/packages/ui/src/components/Primitive/LoadingStateBar/LoadingStateBar.test.tsx
+++ b/packages/ui/src/components/Primitive/LoadingStateBar/LoadingStateBar.test.tsx
@@ -1,0 +1,79 @@
+import { SEMANTIC_COLOR_SCHEMES } from "@repo/theme/semantics"
+import { render, screen } from "@repo/ui/test-utils"
+import { isValidElement } from "react"
+import * as LoadingStateBarModule from "./index"
+import { LoadingStateBar } from "./LoadingStateBar"
+
+describe("<LoadingStateBar />", () => {
+  it("should re-export the LoadingStateBar component and check if LoadingStateBar exists", () => {
+    expect(LoadingStateBarModule.LoadingStateBar).toBeDefined()
+
+    expect(isValidElement(<LoadingStateBarModule.LoadingStateBar />)).toBeTruthy()
+  })
+
+  it("renders with default props", () => {
+    render(<LoadingStateBar />)
+    const progressBar = screen.getByRole("meter")
+    expect(progressBar).toBeInTheDocument()
+    expect(progressBar).toHaveAttribute("aria-disabled", "false")
+  })
+
+  it("renders with value prop", () => {
+    render(<LoadingStateBar value={75} />)
+    const progressBar = screen.getByRole("meter")
+    expect(progressBar).toBeInTheDocument()
+    expect(progressBar).toHaveAttribute("aria-valuenow", "75")
+  })
+
+  it("handles disabled state", () => {
+    render(<LoadingStateBar disabled={true} />)
+    const progressBar = screen.getByRole("meter")
+    expect(progressBar).toHaveAttribute("aria-disabled", "true")
+  })
+
+  it("forwards ref correctly", () => {
+    const ref = { current: null }
+    render(<LoadingStateBar ref={ref} />)
+    expect(ref.current).toBeInstanceOf(HTMLDivElement)
+  })
+
+  it("passes through Progress props correctly", () => {
+    render(<LoadingStateBar colorScheme="primary" max={200} min={10} size="lg" value={100} />)
+    const progressBar = screen.getByRole("meter")
+    expect(progressBar).toBeInTheDocument()
+    expect(progressBar).toHaveAttribute("aria-valuenow", "100")
+    expect(progressBar).toHaveAttribute("aria-valuemax", "200")
+    expect(progressBar).toHaveAttribute("aria-valuemin", "10")
+  })
+
+  test.each(["xs", "sm", "md", "lg"] as const)("handles different size variations: %s", (size) => {
+    render(<LoadingStateBar size={size} value={50} />)
+    const progressBar = screen.getByRole("meter")
+    expect(progressBar).toBeInTheDocument()
+  })
+
+  test.each(SEMANTIC_COLOR_SCHEMES)("handles various color schemes: %s", (colorScheme) => {
+    render(<LoadingStateBar colorScheme={colorScheme} value={50} />)
+    const progressBar = screen.getByRole("meter")
+    expect(progressBar).toBeInTheDocument()
+  })
+
+  it("renders correctly when disabled with value", () => {
+    render(<LoadingStateBar disabled value={30} />)
+    const progressBar = screen.getByRole("meter")
+    expect(progressBar).toHaveAttribute("aria-disabled", "true")
+    expect(progressBar).toHaveAttribute("aria-valuenow", "30")
+  })
+
+  it("handles zero value correctly", () => {
+    render(<LoadingStateBar value={0} />)
+    const progressBar = screen.getByRole("meter")
+    expect(progressBar).toHaveAttribute("aria-valuenow", "0")
+  })
+
+  it("handles maximum value correctly", () => {
+    render(<LoadingStateBar value={100} />)
+    const progressBar = screen.getByRole("meter")
+    expect(progressBar).toHaveAttribute("aria-valuenow", "100")
+  })
+})

--- a/packages/ui/src/components/Primitive/LoadingStateBar/LoadingStateBar.tsx
+++ b/packages/ui/src/components/Primitive/LoadingStateBar/LoadingStateBar.tsx
@@ -1,13 +1,42 @@
 import { Progress, type ProgressProps } from "@yamada-ui/react"
 import { forwardRef, memo } from "react"
 
+/**
+ * Props for the LoadingStateBar component
+ */
 export interface LoadingStateBarProps extends ProgressProps {
   /**
    * Whether the loading bar is disabled
+   * When true, displays a dark overlay on the progress bar
    */
   disabled?: boolean
 }
 
+/**
+ * Loading State Bar component based on Yamada UI Progress
+ *
+ * A progress bar component that shows loading progress with an optional disabled state.
+ * When disabled, it displays a semi-transparent overlay to indicate the loading is paused.
+ *
+ * @param props - Combined Yamada UI Progress props and LoadingStateBar options
+ * @returns A memoized progress bar component
+ *
+ * @example
+ * // Basic loading bar with 50% progress
+ * <LoadingStateBar value={50} />
+ *
+ * @example
+ * // Disabled loading bar
+ * <LoadingStateBar value={30} disabled />
+ *
+ * @example
+ * // With custom color and size
+ * <LoadingStateBar value={75} colorScheme="primary" size="lg" />
+ *
+ * @example
+ * // Indeterminate loading (no value)
+ * <LoadingStateBar isAnimation />
+ */
 export const LoadingStateBar = memo(
   forwardRef<HTMLDivElement, LoadingStateBarProps>(({ disabled = false, ...props }, ref) => {
     return (

--- a/packages/ui/src/components/Primitive/LoadingStateBar/LoadingStateBar.tsx
+++ b/packages/ui/src/components/Primitive/LoadingStateBar/LoadingStateBar.tsx
@@ -1,0 +1,35 @@
+import { Progress, type ProgressProps } from "@yamada-ui/react"
+import { forwardRef, memo } from "react"
+
+export interface LoadingStateBarProps extends ProgressProps {
+  /**
+   * Whether the loading bar is disabled
+   */
+  disabled?: boolean
+}
+
+export const LoadingStateBar = memo(
+  forwardRef<HTMLDivElement, LoadingStateBarProps>(({ disabled = false, ...props }, ref) => {
+    return (
+      <Progress
+        _disabled={{
+          _before: {
+            bg: "blackAlpha.500",
+            w: "100%",
+            h: "100%",
+            position: "absolute",
+            top: 0,
+            left: 0,
+            zIndex: 1,
+          },
+        }}
+        aria-disabled={disabled}
+        ref={ref}
+        rounded="full"
+        {...props}
+      />
+    )
+  }),
+)
+
+LoadingStateBar.displayName = "LoadingStateBar"

--- a/packages/ui/src/components/Primitive/LoadingStateBar/index.ts
+++ b/packages/ui/src/components/Primitive/LoadingStateBar/index.ts
@@ -1,0 +1,2 @@
+export type { LoadingStateBarProps } from "./LoadingStateBar"
+export { LoadingStateBar } from "./LoadingStateBar"

--- a/packages/ui/src/components/Primitive/index.ts
+++ b/packages/ui/src/components/Primitive/index.ts
@@ -1,4 +1,5 @@
 export * from "./Button"
 export * from "./Heading"
 export * from "./Image"
+export * from "./LoadingStateBar"
 export * from "./TextInput"


### PR DESCRIPTION
# Description

I have added a loading state bar primitive component.

![image](https://github.com/user-attachments/assets/e4d0cb49-0ae2-4fc2-8575-94b1963d502f)

> [!NOTE]
> I think this should be in primitive over generic because it is a minimal component that extends `Progress` component from Yamada UI which renders one div with one child element. 

Closes #325

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)
- [x] Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added thorough tests that prove my fix is effective and that my feature works
- [x] I've requested a review from another user
