### PR TITLE
ci(biome): use the biome setup instead of pnpm

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -291,8 +291,6 @@ jobs:
 
       - name: Setup Biome
         uses: biomejs/setup-biome@v2
-        with:
-          version: latest
 
       - name: Run Biome
         run: biome ci . --error-on-warnings


### PR DESCRIPTION
# Description

I have switched biome to use the biome setup instead of pnpm.

https://biomejs.dev/recipes/continuous-integration/#github-actions

Closes #342

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [ ] Manual testing (requires screenshots or videos)
- [x] Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added thorough tests that prove my fix is effective and that my feature works
- [ ] I've requested a review from another user
