### PR TITLE
feat(about-us): add AboutUsSection mobile component

### DIFF
--- a/packages/theme/src/components/button.ts
+++ b/packages/theme/src/components/button.ts
@@ -5,7 +5,7 @@ export const Button: ComponentStyle<"Button"> = {
   baseStyle: {
     cursor: "pointer",
 
-    fontWeight: "semibold",
+    fontWeight: { base: "normal", md: "semibold" },
     transitionDuration: "slower",
     transitionProperty: "common",
     _disabled: {

--- a/packages/ui/src/components/Generic/AboutUsCard/AboutUsCard.tsx
+++ b/packages/ui/src/components/Generic/AboutUsCard/AboutUsCard.tsx
@@ -13,8 +13,6 @@ export const AboutUsCard = ({ title, description }: AboutUsCardProps) => {
       backdropBlur="15px"
       backdropFilter="auto"
       bg={["secondary.50", "secondary.800"]}
-      borderColor="transparent"
-      borderWidth="1px"
       boxShadow="0px 1.5px 0px 0px rgba(0, 0, 0, 0.05), 0px 6px 6px 0px rgba(0, 0, 0, 0.05), 0px 15px 15px 0px rgba(0, 0, 0, 0.1)"
       gap="md"
       justifyContent="center"

--- a/packages/ui/src/components/Generic/AboutUsCard/index.ts
+++ b/packages/ui/src/components/Generic/AboutUsCard/index.ts
@@ -1,0 +1,1 @@
+export * from "./AboutUsCard"

--- a/packages/ui/src/components/Generic/AboutUsSection/AboutUsSection.stories.tsx
+++ b/packages/ui/src/components/Generic/AboutUsSection/AboutUsSection.stories.tsx
@@ -1,0 +1,72 @@
+import type { Meta, StoryObj } from "@storybook/react"
+import { AboutUsSection } from "./AboutUsSection"
+
+const meta: Meta<typeof AboutUsSection> = {
+  title: "Generic Components / AboutUsSection",
+  component: AboutUsSection,
+  argTypes: {
+    cards: {
+      control: "object",
+      description: "Array of AboutUsCardProps to display in the section",
+      table: {
+        type: { summary: "AboutUsCardProps[]" },
+        defaultValue: { summary: "[]" },
+      },
+    },
+    items: {
+      control: "object",
+      description: "Array of items for the AboutUsCarousel",
+      table: {
+        type: { summary: "AboutUsCarouselProps['items']" },
+        defaultValue: { summary: "[]" },
+      },
+    },
+  },
+  args: {
+    items: [
+      {
+        src: "https://images.unsplash.com/photo-1506744038136-46273834b3fb?w=600",
+        alt: "Mountain Lake",
+        width: 600,
+        height: 400,
+        emoji: "😄",
+      },
+      {
+        src: "https://images.unsplash.com/photo-1465101046530-73398c7f28ca?w=600",
+        alt: "Forest Path",
+        width: 600,
+        height: 400,
+        emoji: "😁",
+      },
+      {
+        src: "https://images.unsplash.com/photo-1519125323398-675f0ddb6308?w=600",
+        alt: "Desert Dunes",
+        width: 600,
+        height: 400,
+        emoji: "😆",
+      },
+    ],
+    cards: [
+      {
+        title: "Who We Are",
+        description:
+          "UABC Badminton Club is the official badminton team of UOA, bringing together students who love the game — from absolute beginners to competitive players.",
+      },
+      {
+        title: "Who We Are",
+        description:
+          "UABC Badminton Club is the official badminton team of UOA, bringing together students who love the game — from absolute beginners to competitive players.",
+      },
+      {
+        title: "Who We Are",
+        description:
+          "UABC Badminton Club is the official badminton team of UOA, bringing together students who love the game — from absolute beginners to competitive players.",
+      },
+    ],
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof AboutUsSection>
+
+export const Default: Story = {}

--- a/packages/ui/src/components/Generic/AboutUsSection/AboutUsSection.test.tsx
+++ b/packages/ui/src/components/Generic/AboutUsSection/AboutUsSection.test.tsx
@@ -1,0 +1,63 @@
+import { mockImagesWithEmoji } from "@repo/ui/test-config/mocks/AboutUsCarousel.mock"
+import { render, screen } from "@repo/ui/test-utils"
+import { isValidElement } from "react"
+import { AboutUsSection } from "./AboutUsSection"
+
+const IntersectionObserverMock = vi.fn(() => ({
+  disconnect: vi.fn(),
+  observe: vi.fn(),
+  takeRecords: vi.fn(),
+  unobserve: vi.fn(),
+}))
+
+vi.stubGlobal("IntersectionObserver", IntersectionObserverMock)
+
+describe("<AboutUsSection />", () => {
+  it("should re-export the AboutUsSection component and check if AboutUsSection component exists", () => {
+    expect(AboutUsSection).toBeDefined()
+    expect(isValidElement(<AboutUsSection cards={[]} items={mockImagesWithEmoji} />)).toBeTruthy()
+  })
+
+  it("should have correct displayName", () => {
+    expect(AboutUsSection.displayName).toBe("AboutUsSection")
+  })
+
+  it("should render the section with a heading", () => {
+    render(<AboutUsSection cards={[]} items={mockImagesWithEmoji} />)
+
+    expect(screen.getByRole("heading", { level: 2 })).toBeInTheDocument()
+    expect(screen.getByText("About Us")).toBeInTheDocument()
+  })
+
+  it("should render the Learn More button", () => {
+    render(<AboutUsSection cards={[]} items={mockImagesWithEmoji} />)
+
+    const button = screen.getByRole("link", { name: "Learn More" })
+    expect(button).toBeInTheDocument()
+    expect(button).toHaveAttribute("href", "/about")
+  })
+
+  it("should render the AboutUsCarousel component", () => {
+    render(<AboutUsSection cards={[]} items={mockImagesWithEmoji} />)
+
+    const carousel = screen.getByTestId("about-us-carousel")
+    expect(carousel).toBeInTheDocument()
+  })
+
+  it("should render AboutUsCard components for each card", () => {
+    const cards = [
+      { title: "Card 1", description: "Description 1" },
+      { title: "Card 2", description: "Description 2" },
+      { title: "Card 3", description: "Description 3" },
+    ]
+
+    render(<AboutUsSection cards={cards} items={mockImagesWithEmoji} />)
+
+    expect(screen.getByText("Card 1")).toBeInTheDocument()
+    expect(screen.getByText("Description 1")).toBeInTheDocument()
+    expect(screen.getByText("Card 2")).toBeInTheDocument()
+    expect(screen.getByText("Description 2")).toBeInTheDocument()
+    expect(screen.getByText("Card 3")).toBeInTheDocument()
+    expect(screen.getByText("Description 3")).toBeInTheDocument()
+  })
+})

--- a/packages/ui/src/components/Generic/AboutUsSection/AboutUsSection.tsx
+++ b/packages/ui/src/components/Generic/AboutUsSection/AboutUsSection.tsx
@@ -1,0 +1,43 @@
+import { AboutUsCard, type AboutUsCardProps } from "@repo/ui/components/Generic/AboutUsCard"
+import {
+  AboutUsCarousel,
+  type AboutUsCarouselProps,
+} from "@repo/ui/components/Generic/AboutUsCarousel"
+import { Button, Heading } from "@repo/ui/components/Primitive"
+import { Container, Flex, VStack } from "@yamada-ui/react"
+import Link from "next/link"
+
+export interface AboutUsSectionProps extends AboutUsCarouselProps {
+  cards: AboutUsCardProps[]
+}
+
+export const AboutUsSection = ({ cards, ...carouselProps }: AboutUsSectionProps) => {
+  return (
+    <Container as={VStack} centerContent gap="md" padding="calc(lg - sm)">
+      <Heading.h2 fontWeight="semibold" w="full">
+        About Us
+      </Heading.h2>
+      <VStack gap="2xl">
+        <AboutUsCarousel
+          data-testid="about-us-carousel"
+          wrapperProps={{ padding: { sm: "sm" } }}
+          {...carouselProps}
+          autoplay
+          delay={4000}
+          height="auto"
+          width="full"
+        />
+        <Flex flexDir={{ base: "column", md: "row" }} gap="md">
+          {cards.map((card) => (
+            <AboutUsCard key={card.title} {...card} />
+          ))}
+        </Flex>
+      </VStack>
+      <Button as={Link} colorScheme="primary" href="/about" size="lg">
+        Learn More
+      </Button>
+    </Container>
+  )
+}
+
+AboutUsSection.displayName = "AboutUsSection"

--- a/packages/ui/src/components/Generic/AboutUsSection/index.ts
+++ b/packages/ui/src/components/Generic/AboutUsSection/index.ts
@@ -1,0 +1,1 @@
+export * from "./AboutUsSection"


### PR DESCRIPTION
# Description

Added AboutUsSection component with mobile styling, along with relevant tests and stories.

Fixes #337 

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

<img width="417" alt="Screenshot 2025-07-09 at 22 26 02" src="https://github.com/user-attachments/assets/5b848888-50e3-49c7-a904-dc633b322841" />
<img width="417" alt="Screenshot 2025-07-09 at 22 26 29" src="https://github.com/user-attachments/assets/e3452d25-4655-40dc-ac82-0f60a43dbbe8" />

- [x] Manual testing (requires screenshots or videos)
- [x] Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added thorough tests that prove my fix is effective and that my feature works
- [x] I've requested a review from another user
