### PR TITLE
fix(ci): skip storybook deploy on master branch

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -129,7 +129,7 @@ jobs:
 
   preview-storybook:
     needs: [build-storybook]
-    if: ${{ 'false' == 'true' }}
+    if: ${{ (github.ref != 'refs/heads/master') && needs.check_changes.outputs.exists == 'true' }}
     runs-on: ubuntu-latest
     outputs:
       deployment-url: ${{ steps.deploy-storybook.outputs.deployment-url }}

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -129,7 +129,7 @@ jobs:
 
   preview-storybook:
     needs: [build-storybook]
-    if: ${{ (github.ref != 'refs/heads/master') && needs.check_changes.outputs.exists == 'true' }}
+    if: ${{ 'false' == 'true' }}
     runs-on: ubuntu-latest
     outputs:
       deployment-url: ${{ steps.deploy-storybook.outputs.deployment-url }}

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -129,7 +129,7 @@ jobs:
 
   preview-storybook:
     needs: [build-storybook]
-    if: ${{ needs.check_changes.outputs.exists == 'true' }}
+    if: ${{ (github.ref != 'refs/heads/master') && needs.check_changes.outputs.exists == 'true' }}
     runs-on: ubuntu-latest
     outputs:
       deployment-url: ${{ steps.deploy-storybook.outputs.deployment-url }}


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes towards the related issue. Please also  include relevant context. List any dependencies that are required for this change. -->

Fixes the issue where preview storybook deployment would run on master branch. 

Fixes #448 

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Seems to cancel the `comment` job as well if storybook preview is disabled. 

Tested in [80b2231](https://github.com/UoaWDCC/uabc-web/pull/449/commits/80b223187549cb7d0d8ccd8d8c3d1d58a1d62b4c).

<img width="764" height="324" alt="Screenshot 2025-07-11 at 8 56 39 PM" src="https://github.com/user-attachments/assets/06249aeb-4768-4c91-8ee7-2ad6d129023f" />

- [x] Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added thorough tests that prove my fix is effective and that my feature works
- [x] I've requested a review from another user
