### PR TITLE
build: remove auto deployment message within pull requests

### DIFF
--- a/.github/cd-actions/deploy-frontend/action.yml
+++ b/.github/cd-actions/deploy-frontend/action.yml
@@ -11,7 +11,7 @@ inputs:
     required: true
   GH_TOKEN:
     description: 'GitHub token'
-    required: true
+    required: false
   # Frontend secrets
   NEXT_PUBLIC_URL:
     description: 'Frontend URL'

--- a/.github/cd-actions/deploy-storybook/action.yml
+++ b/.github/cd-actions/deploy-storybook/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: true
   GH_TOKEN:
     description: 'GitHub token'
-    required: true
+    required: false
 
 outputs:
   deployment-url:

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -160,7 +160,6 @@ jobs:
         with:
           CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NEXT_PUBLIC_URL: ${{ vars.NEXT_PUBLIC_URL }}
           NEXT_PUBLIC_API_URL: ${{ vars.NEXT_PUBLIC_API_URL }}
           project-name: uabc

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -143,7 +143,6 @@ jobs:
         with:
           CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   preview-frontend:
     needs: [check_changes, setup]


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes towards the related issue. Please also  include relevant context. List any dependencies that are required for this change. -->

Removed the `GITHUB_TOKEN` input for preview deployments. This no longer results in the PR spam of auto preview deployments. 

Fixes #472 

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

No longer the 
`@github-actions github-actions bot deployed to preview`

<img width="985" height="530" alt="image" src="https://github.com/user-attachments/assets/0b2bca3f-63c3-4d75-b293-ea5d9c7d869c" />

- [x] Manual testing (requires screenshots or videos)
- [ ] Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added thorough tests that prove my fix is effective and that my feature works
- [x] I've requested a review from another user
