### PR TITLE
refactor(auth): enable header based authentication for production env

### DIFF
--- a/apps/backend/src/business-layer/security/authentication.ts
+++ b/apps/backend/src/business-layer/security/authentication.ts
@@ -17,18 +17,11 @@ export default async function authenticate(securityName: "jwt", scopes?: string[
     try {
       let token: string = cookieStore.get(AUTH_COOKIE_NAME)?.value || ""
 
-      // Enable header based auth when NODE_ENV set the test mode
-      if (process.env.NODE_ENV !== "production") {
-        const authHeader = headersList.get("authorization") || ""
-        if (!token && !authHeader.startsWith("Bearer ")) {
-          throw new UnauthorizedAuthError("No token provided")
-        }
-        if (!token) token = authHeader.split(" ")[1] // Gets part after Bearer
-      }
-
-      if (!token) {
+      const authHeader = headersList.get("authorization") || ""
+      if (!token && !authHeader.startsWith("Bearer ")) {
         throw new UnauthorizedAuthError("No token provided")
       }
+      if (!token) token = authHeader.split(" ")[1] // Gets part after Bearer
 
       const authService = new AuthService()
       const decodedToken = authService.getData(token, JWTEncryptedUserSchema)


### PR DESCRIPTION
# Description

Removed logic checking for NODE_ENV !== production so header based auth is enabled for both test and production.

Fixes #464 

## Type of change
<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [ ] Manual testing (requires screenshots or videos)
- [ ] Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added thorough tests that prove my fix is effective and that my feature works
- [ ] I've requested a review from another user
