### PR TITLE
refactor(cd): seperate staging and production environments

### DIFF
--- a/.github/cd-actions/deploy-backend/action.yml
+++ b/.github/cd-actions/deploy-backend/action.yml
@@ -63,9 +63,9 @@ runs:
         TURBO_TEAM=${{ inputs.TURBO_TEAM }}
         TURBO_TOKEN=${{ inputs.TURBO_TOKEN }}
         NEXT_PUBLIC_URL=${{ inputs.NEXT_PUBLIC_URL }}
-        SMTP_HOST=${{ inputs.SMTP_HOST }}
-        SMTP_USER=${{ inputs.SMTP_USER }}
-        SMTP_PASS=${{ inputs.SMTP_PASS }}
+        SMTP_HOST="${{ inputs.SMTP_HOST }}"
+        SMTP_USER="${{ inputs.SMTP_USER }}"
+        SMTP_PASS="${{ inputs.SMTP_PASS }}"
 
     - name: Deploy Backend Secrets
       env:

--- a/.github/cd-actions/deploy-backend/action.yml
+++ b/.github/cd-actions/deploy-backend/action.yml
@@ -53,7 +53,7 @@ runs:
       shell: bash
       id: backend-secrets
       run: >
-        flyctl inputs set --config apps/backend/${{ inputs.FLY_CONFIG_PATH }}
+        flyctl secrets set --config apps/backend/${{ inputs.FLY_CONFIG_PATH }}
         DATABASE_URI=${{ inputs.DATABASE_URI }}
         JWT_SECRET=${{ inputs.JWT_SECRET }}
         PAYLOAD_SECRET=${{ inputs.PAYLOAD_SECRET }}

--- a/.github/cd-actions/deploy-backend/action.yml
+++ b/.github/cd-actions/deploy-backend/action.yml
@@ -1,0 +1,94 @@
+name: Deploy Backend
+description: Deploys backend
+
+inputs:
+  # Deployment config
+  FLY_API_TOKEN:
+    description: The Fly API token
+    required: true
+  FLY_CONFIG_PATH:
+    description: The path to the Fly.toml file
+    required: true
+  # Secrets
+  DATABASE_URI:
+    description: The database URI
+    required: true
+  JWT_SECRET:
+    description: The JWT Secret
+    required: true
+  PAYLOAD_SECRET:
+    description: The payload secret
+    required: true
+  GOOGLE_CLIENT_ID:
+    description: The Google client ID
+    required: true
+  GOOGLE_CLIENT_SECRET:
+    description: The Google client secret
+    required: true
+  NEXT_PUBLIC_URL:
+    description: The Next.js public URL
+    required: true
+  TURBO_TEAM:
+    description: The Turbo team
+    required: true
+  TURBO_TOKEN:
+    description: The Turbo token
+    required: true
+  SMTP_HOST:
+    description: The SMTP host
+    required: false
+  SMTP_USER:
+    description: The SMTP user
+    required: false
+  SMTP_PASS:
+    description: The SMTP password
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: Set Backend Secrets
+      env:
+        FLY_API_TOKEN: ${{ inputs.FLY_API_TOKEN }}
+      shell: bash
+      id: backend-secrets
+      run: >
+        flyctl inputs set --config apps/backend/${{ inputs.FLY_CONFIG_PATH }}
+        DATABASE_URI=${{ inputs.DATABASE_URI }}
+        JWT_SECRET=${{ inputs.JWT_SECRET }}
+        PAYLOAD_SECRET=${{ inputs.PAYLOAD_SECRET }}
+        GOOGLE_CLIENT_ID=${{ inputs.GOOGLE_CLIENT_ID }}
+        GOOGLE_CLIENT_SECRET=${{ inputs.GOOGLE_CLIENT_SECRET }}
+        NEXT_PUBLIC_URL=${{ inputs.NEXT_PUBLIC_URL }}
+        TURBO_TEAM=${{ inputs.TURBO_TEAM }}
+        TURBO_TOKEN=${{ inputs.TURBO_TOKEN }}
+        NEXT_PUBLIC_URL=${{ inputs.NEXT_PUBLIC_URL }}
+        SMTP_HOST=${{ inputs.SMTP_HOST }}
+        SMTP_USER=${{ inputs.SMTP_USER }}
+        SMTP_PASS=${{ inputs.SMTP_PASS }}
+
+    - name: Deploy Backend Secrets
+      env:
+        FLY_API_TOKEN: ${{ inputs.FLY_API_TOKEN }}
+      shell: bash
+      id: backend-secrets-deploy
+      run: flyctl secrets deploy --config apps/backend/${{ inputs.FLY_CONFIG_PATH }}
+
+    - name: Deploy Backend
+      env:
+        FLY_API_TOKEN: ${{ inputs.FLY_API_TOKEN }}
+      shell: bash
+      id: deploy-backend
+      run: >
+        flyctl deploy --remote-only --config apps/backend/${{ inputs.FLY_CONFIG_PATH }}
+        --build-arg DATABASE_URI="${{ inputs.DATABASE_URI }}"
+        --build-arg JWT_SECRET="${{ inputs.JWT_SECRET }}"
+        --build-arg PAYLOAD_SECRET="${{ inputs.PAYLOAD_SECRET }}"
+        --build-arg GOOGLE_CLIENT_ID="${{ inputs.GOOGLE_CLIENT_ID }}"
+        --build-arg GOOGLE_CLIENT_SECRET="${{ inputs.GOOGLE_CLIENT_SECRET }}"
+        --build-arg NEXT_PUBLIC_URL="${{ inputs.NEXT_PUBLIC_URL }}"
+        --build-arg TURBO_TEAM="${{ inputs.TURBO_TEAM }}"
+        --build-arg TURBO_TOKEN="${{ inputs.TURBO_TOKEN }}"
+        --build-arg SMTP_HOST="${{ inputs.SMTP_HOST }}"
+        --build-arg SMTP_USER="${{ inputs.SMTP_USER }}"
+        --build-arg SMTP_PASS="${{ inputs.SMTP_PASS }}"

--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -26,7 +26,7 @@ jobs:
       group: ${{ github.workflow }}-deploy-backend-staging
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
       - name: Deploy Backend Staging
@@ -83,7 +83,7 @@ jobs:
       group: ${{ github.workflow }}-deploy-backend-production
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
       - name: Deploy Backend Production

--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -18,11 +18,9 @@ jobs:
   deploy-backend-staging:
     name: Deploy Backend
     if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'backend-staging')
-    env:
-      FLY_API_TOKEN: ${{ secrets.FLY_SERVER_API_TOKEN }}
     environment:
       name: staging
-      url: https://wdcc-uabc-backend-staging.fly.dev/
+      url: https://staging-server.uoabadminton.co.nz
     runs-on: ubuntu-latest
     concurrency:
       group: ${{ github.workflow }}-deploy-backend-staging
@@ -31,37 +29,20 @@ jobs:
       - uses: actions/checkout@v3
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
-      - name: Set Backend Secrets
-        id: backend-secrets
-        run: >
-          flyctl secrets set --config apps/backend/fly.staging.toml
-          DATABASE_URI=${{ secrets.DATABASE_URI }}
-          JWT_SECRET=${{ secrets.JWT_SECRET }}
-          PAYLOAD_SECRET=${{ secrets.PAYLOAD_SECRET }}
-          GOOGLE_CLIENT_ID=${{ secrets.GOOGLE_CLIENT_ID }}
-          GOOGLE_CLIENT_SECRET=${{ secrets.GOOGLE_CLIENT_SECRET }}
-          NEXT_PUBLIC_URL=${{ secrets.NEXT_PUBLIC_URL }}
-          TURBO_TEAM=${{ vars.TURBO_TEAM }}
-          TURBO_TOKEN=${{ secrets.TURBO_TOKEN }}
-          NEXT_PUBLIC_URL=${{ secrets.NEXT_PUBLIC_URL }}
-
-      - name: Deploy Backend Secrets
-        id: backend-secrets-deploy
-        run: flyctl secrets deploy --config apps/backend/fly.staging.toml
-
       - name: Deploy Backend
         id: deploy-backend
-        run: >
-          flyctl deploy --remote-only --config apps/backend/fly.staging.toml
-          --build-arg DATABASE_URI="${{ secrets.DATABASE_URI }}"
-          --build-arg JWT_SECRET="${{ secrets.JWT_SECRET }}"
-          --build-arg PAYLOAD_SECRET="${{ secrets.PAYLOAD_SECRET }}"
-          --build-arg GOOGLE_CLIENT_ID="${{ secrets.GOOGLE_CLIENT_ID }}"
-          --build-arg GOOGLE_CLIENT_SECRET="${{ secrets.GOOGLE_CLIENT_SECRET }}"
-          --build-arg NEXT_PUBLIC_URL="${{ secrets.NEXT_PUBLIC_URL }}"
-          --build-arg TURBO_TEAM="${{ vars.TURBO_TEAM }}"
-          --build-arg TURBO_TOKEN="${{ secrets.TURBO_TOKEN }}"
-          --build-arg NEXT_PUBLIC_API_URL="${{ secrets.NEXT_PUBLIC_API_URL }}"
+        uses: ./.github/cd-actions/deploy-backend/
+        with:
+          FLY_CONFIG_PATH: fly.staging.toml
+          DATABASE_URI: ${{ secrets.DATABASE_URI }}
+          JWT_SECRET: ${{ secrets.JWT_SECRET }}
+          PAYLOAD_SECRET: ${{ secrets.PAYLOAD_SECRET }}
+          GOOGLE_CLIENT_ID: ${{ vars.GOOGLE_CLIENT_ID }}
+          GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+          NEXT_PUBLIC_URL: ${{ vars.NEXT_PUBLIC_URL }}
+          TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
   deploy-frontend-staging:
     name: Deploy Frontend Staging
@@ -114,3 +95,35 @@ jobs:
           NODE_ENV: production
           project-name: uabc
           APP_INDEX_MODE: NOINDEX
+
+  deploy-backend-production:
+    name: Deploy Backend
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'backend-staging')
+    environment:
+      name: production
+      url: https://server.uoabadminton.co.nz/
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-deploy-backend-staging
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v3
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Deploy Backend
+        id: deploy-backend
+        uses: ./.github/cd-actions/deploy-backend/
+        with:
+          FLY_CONFIG_PATH: fly.production.toml
+          DATABASE_URI: ${{ secrets.DATABASE_URI }}
+          JWT_SECRET: ${{ secrets.JWT_SECRET }}
+          PAYLOAD_SECRET: ${{ secrets.PAYLOAD_SECRET }}
+          GOOGLE_CLIENT_ID: ${{ vars.GOOGLE_CLIENT_ID }}
+          GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+          NEXT_PUBLIC_URL: ${{ vars.NEXT_PUBLIC_URL }}
+          TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          SMTP_HOST: ${{ secrets.SMTP_HOST }}
+          SMTP_USER: ${{ secrets.SMTP_USER }}
+          SMTP_PASS: ${{ secrets.SMTP_PASS }}
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -102,9 +102,9 @@ jobs:
           NEXT_PUBLIC_URL: ${{ vars.NEXT_PUBLIC_URL }}
           TURBO_TEAM: ${{ vars.TURBO_TEAM }}
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-          # SMTP_HOST: ${{ secrets.SMTP_HOST }}
-          # SMTP_USER: ${{ secrets.SMTP_USER }}
-          # SMTP_PASS: ${{ secrets.SMTP_PASS }}
+          SMTP_HOST: ${{ secrets.SMTP_HOST }}
+          SMTP_USER: ${{ secrets.SMTP_USER }}
+          SMTP_PASS: ${{ secrets.SMTP_PASS }}
 
   deploy-frontend-production:
     name: Deploy Frontend Production

--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -19,7 +19,7 @@ jobs:
     name: Deploy Backend Staging
     if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'backend-staging')
     environment:
-      name: staging
+      name: backend-staging
       url: https://staging-server.uoabadminton.co.nz
     runs-on: ubuntu-latest
     concurrency:
@@ -50,7 +50,7 @@ jobs:
     name: Deploy Frontend Staging
     if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'frontend-staging')
     environment:
-      name: staging
+      name: frontend-staging
       url: https://staging.uoabadminton.co.nz/
     runs-on: ubuntu-latest
     concurrency:
@@ -76,7 +76,7 @@ jobs:
     name: Deploy Backend Production
     if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'backend-production')
     environment:
-      name: production
+      name: backend-production
       url: https://server.uoabadminton.co.nz/
     runs-on: ubuntu-latest
     concurrency:
@@ -110,7 +110,7 @@ jobs:
     name: Deploy Frontend Production
     if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'frontend-production')
     environment:
-      name: staging
+      name: frontend-staging
       url: https://uoabadminton.co.nz/
     runs-on: ubuntu-latest
     concurrency:

--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -72,32 +72,6 @@ jobs:
           project-name: uabc-staging
           APP_INDEX_MODE: NOINDEX
 
-  deploy-frontend-production:
-    name: Deploy Frontend Production
-    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'frontend-production')
-    environment:
-      name: staging
-      url: https://uoabadminton.co.nz/
-    runs-on: ubuntu-latest
-    concurrency:
-      group: ${{ github.workflow }}-deploy-frontend-production
-      cancel-in-progress: true
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Deploy Frontend
-        id: deploy-frontend
-        uses: ./.github/cd-actions/deploy-frontend/
-        with:
-          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NEXT_PUBLIC_URL: ${{ vars.NEXT_PUBLIC_URL }}
-          NEXT_PUBLIC_API_URL: ${{ vars.NEXT_PUBLIC_API_URL }}
-          NODE_ENV: production
-          project-name: uabc
-          APP_INDEX_MODE: NOINDEX
-
   deploy-backend-production:
     name: Deploy Backend Production
     if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'backend-production')
@@ -131,3 +105,29 @@ jobs:
           SMTP_HOST: ${{ secrets.SMTP_HOST }}
           SMTP_USER: ${{ secrets.SMTP_USER }}
           SMTP_PASS: ${{ secrets.SMTP_PASS }}
+
+  deploy-frontend-production:
+    name: Deploy Frontend Production
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'frontend-production')
+    environment:
+      name: staging
+      url: https://uoabadminton.co.nz/
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-deploy-frontend-production
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Deploy Frontend
+        id: deploy-frontend
+        uses: ./.github/cd-actions/deploy-frontend/
+        with:
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEXT_PUBLIC_URL: ${{ vars.NEXT_PUBLIC_URL }}
+          NEXT_PUBLIC_API_URL: ${{ vars.NEXT_PUBLIC_API_URL }}
+          NODE_ENV: production
+          project-name: uabc
+          APP_INDEX_MODE: NOINDEX

--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -80,7 +80,7 @@ jobs:
       url: https://server.uoabadminton.co.nz/
     runs-on: ubuntu-latest
     concurrency:
-      group: ${{ github.workflow }}-deploy-backend-staging
+      group: ${{ github.workflow }}-deploy-backend-production
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -15,9 +15,9 @@ on:
         required: true
 
 jobs:
-  deploy-backend:
+  deploy-backend-staging:
     name: Deploy Backend
-    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && (github.event.inputs.environment == 'staging' || github.event.inputs.environment == 'backend-staging'))
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'backend-staging')
     env:
       FLY_API_TOKEN: ${{ secrets.FLY_SERVER_API_TOKEN }}
     environment:
@@ -25,7 +25,7 @@ jobs:
       url: https://wdcc-uabc-backend-staging.fly.dev/
     runs-on: ubuntu-latest
     concurrency:
-      group: ${{ github.workflow }}-deploy-backend
+      group: ${{ github.workflow }}-deploy-backend-staging
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v3
@@ -44,7 +44,6 @@ jobs:
           TURBO_TEAM=${{ vars.TURBO_TEAM }}
           TURBO_TOKEN=${{ secrets.TURBO_TOKEN }}
           NEXT_PUBLIC_URL=${{ secrets.NEXT_PUBLIC_URL }}
-          NEXT_PUBLIC_API_URL=${{ secrets.NEXT_PUBLIC_API_URL }}
 
       - name: Deploy Backend Secrets
         id: backend-secrets-deploy
@@ -64,15 +63,15 @@ jobs:
           --build-arg TURBO_TOKEN="${{ secrets.TURBO_TOKEN }}"
           --build-arg NEXT_PUBLIC_API_URL="${{ secrets.NEXT_PUBLIC_API_URL }}"
 
-  deploy-frontend:
-    name: Deploy Frontend
-    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && (github.event.inputs.environment == 'staging' || github.event.inputs.environment == 'frontend-staging'))
+  deploy-frontend-staging:
+    name: Deploy Frontend Staging
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'frontend-staging')
     environment:
       name: staging
-      url: https://uabc.pages.dev/
+      url: https://staging.uoabadminton.co.nz/
     runs-on: ubuntu-latest
     concurrency:
-      group: ${{ github.workflow }}-deploy-frontend
+      group: ${{ github.workflow }}-deploy-frontend-staging
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -87,21 +86,31 @@ jobs:
           NEXT_PUBLIC_URL: ${{ vars.NEXT_PUBLIC_URL }}
           NEXT_PUBLIC_API_URL: ${{ vars.NEXT_PUBLIC_API_URL }}
           NODE_ENV: staging
-          project-name: uabc
+          project-name: uabc-staging
           APP_INDEX_MODE: NOINDEX
 
-  deploy-to-production:
-    name: Deploy UABC Production App
-    if: github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'production'
-    env:
-      FLY_API_TOKEN: ${{ secrets.FLY_APP_API_TOKEN }}
+  deploy-frontend-production:
+    name: Deploy Frontend Production
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'frontend-production')
     environment:
-      name: production
-      url: https://uabc.wdcc.co.nz/
+      name: staging
+      url: https://uoabadminton.co.nz/
     runs-on: ubuntu-latest
     concurrency:
-      group: ${{ github.workflow }}-deploy-production
+      group: ${{ github.workflow }}-deploy-frontend-production
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v3
-      - run: echo "To be implemented"
+      - uses: actions/checkout@v4
+
+      - name: Deploy Frontend
+        id: deploy-frontend
+        uses: ./.github/cd-actions/deploy-frontend/
+        with:
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEXT_PUBLIC_URL: ${{ vars.NEXT_PUBLIC_URL }}
+          NEXT_PUBLIC_API_URL: ${{ vars.NEXT_PUBLIC_API_URL }}
+          NODE_ENV: production
+          project-name: uabc
+          APP_INDEX_MODE: NOINDEX

--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -74,7 +74,7 @@ jobs:
 
   deploy-backend-production:
     name: Deploy Backend Production
-    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'backend-production')
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'backend-production'
     environment:
       name: backend-production
       url: https://server.uoabadminton.co.nz/
@@ -102,13 +102,13 @@ jobs:
           NEXT_PUBLIC_URL: ${{ vars.NEXT_PUBLIC_URL }}
           TURBO_TEAM: ${{ vars.TURBO_TEAM }}
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-          SMTP_HOST: ${{ secrets.SMTP_HOST }}
-          SMTP_USER: ${{ secrets.SMTP_USER }}
-          SMTP_PASS: ${{ secrets.SMTP_PASS }}
+          # SMTP_HOST: ${{ secrets.SMTP_HOST }}
+          # SMTP_USER: ${{ secrets.SMTP_USER }}
+          # SMTP_PASS: ${{ secrets.SMTP_PASS }}
 
   deploy-frontend-production:
     name: Deploy Frontend Production
-    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'frontend-production')
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'frontend-production'
     environment:
       name: frontend-production
       url: https://uoabadminton.co.nz/

--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -110,7 +110,7 @@ jobs:
     name: Deploy Frontend Production
     if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'frontend-production')
     environment:
-      name: frontend-staging
+      name: frontend-production
       url: https://uoabadminton.co.nz/
     runs-on: ubuntu-latest
     concurrency:

--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   deploy-backend-staging:
-    name: Deploy Backend
+    name: Deploy Backend Staging
     if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'backend-staging')
     environment:
       name: staging
@@ -29,11 +29,14 @@ jobs:
       - uses: actions/checkout@v3
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
-      - name: Deploy Backend
+      - name: Deploy Backend Staging
         id: deploy-backend
         uses: ./.github/cd-actions/deploy-backend/
         with:
+          # Deployment secrets/variables
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
           FLY_CONFIG_PATH: fly.staging.toml
+          # Environment secrets/variables
           DATABASE_URI: ${{ secrets.DATABASE_URI }}
           JWT_SECRET: ${{ secrets.JWT_SECRET }}
           PAYLOAD_SECRET: ${{ secrets.PAYLOAD_SECRET }}
@@ -42,7 +45,6 @@ jobs:
           NEXT_PUBLIC_URL: ${{ vars.NEXT_PUBLIC_URL }}
           TURBO_TEAM: ${{ vars.TURBO_TEAM }}
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
   deploy-frontend-staging:
     name: Deploy Frontend Staging
@@ -97,8 +99,8 @@ jobs:
           APP_INDEX_MODE: NOINDEX
 
   deploy-backend-production:
-    name: Deploy Backend
-    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'backend-staging')
+    name: Deploy Backend Production
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'backend-production')
     environment:
       name: production
       url: https://server.uoabadminton.co.nz/
@@ -110,11 +112,14 @@ jobs:
       - uses: actions/checkout@v3
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
-      - name: Deploy Backend
+      - name: Deploy Backend Production
         id: deploy-backend
         uses: ./.github/cd-actions/deploy-backend/
         with:
+          # Deployment secrets/variables
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
           FLY_CONFIG_PATH: fly.production.toml
+          # Environment secrets/variables
           DATABASE_URI: ${{ secrets.DATABASE_URI }}
           JWT_SECRET: ${{ secrets.JWT_SECRET }}
           PAYLOAD_SECRET: ${{ secrets.PAYLOAD_SECRET }}
@@ -126,4 +131,3 @@ jobs:
           SMTP_HOST: ${{ secrets.SMTP_HOST }}
           SMTP_USER: ${{ secrets.SMTP_USER }}
           SMTP_PASS: ${{ secrets.SMTP_PASS }}
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/apps/backend/fly.production.toml
+++ b/apps/backend/fly.production.toml
@@ -1,0 +1,18 @@
+app = 'wdcc-uabc-backend'
+primary_region = 'syd'
+
+[build]
+  context = "."
+  dockerfile = "Dockerfile"
+
+[http_service]
+  internal_port = 3000
+  force_https = true
+  auto_stop_machines = true
+  auto_start_machines = true
+  min_machines_running = 0
+
+[[vm]]
+  cpu_kind = 'shared'
+  cpus = 1
+  memory_mb = 1024

--- a/apps/backend/turbo.json
+++ b/apps/backend/turbo.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "dependsOn": ["@repo/test-config#build"],
+      "env": [
+        "DATABASE_URI",
+        "PAYLOAD_SECRET",
+        "GOOGLE_CLIENT_ID",
+        "GOOGLE_CLIENT_SECRET",
+        "JWT_SECRET",
+        "SMTP_HOST",
+        "SMTP_USER",
+        "SMTP_PASS"
+      ]
+    }
+  }
+}

--- a/turbo.json
+++ b/turbo.json
@@ -9,19 +9,21 @@
     "build": {
       "cache": true,
       "dependsOn": ["^build"],
+      "env": ["TURBO_TEAM", "TURBO_TOKEN"],
+      "inputs": ["$TURBO_DEFAULT$", ".env*"],
+      "outputs": ["dist/**", ".next/**", "!.next/cache/**", "public/dist/**"]
+    },
+    "backend#build": {
       "env": [
         "DATABASE_URI",
         "PAYLOAD_SECRET",
         "GOOGLE_CLIENT_ID",
         "GOOGLE_CLIENT_SECRET",
-        "NEXT_PUBLIC_URL",
-        "NEXT_PUBLIC_API_URL",
         "JWT_SECRET",
-        "TURBO_TEAM",
-        "TURBO_TOKEN"
-      ],
-      "inputs": ["$TURBO_DEFAULT$", ".env*"],
-      "outputs": ["dist/**", ".next/**", "!.next/cache/**", "public/dist/**"]
+        "SMTP_HOST",
+        "SMTP_USER",
+        "SMTP_PASS"
+      ]
     },
     "pages:build": {
       "cache": true,

--- a/turbo.json
+++ b/turbo.json
@@ -14,6 +14,7 @@
       "outputs": ["dist/**", ".next/**", "!.next/cache/**", "public/dist/**"]
     },
     "backend#build": {
+      "dependsOn": ["@repo/test-config#build"],
       "env": [
         "DATABASE_URI",
         "PAYLOAD_SECRET",

--- a/turbo.json
+++ b/turbo.json
@@ -11,20 +11,7 @@
       "dependsOn": ["^build"],
       "env": ["TURBO_TEAM", "TURBO_TOKEN"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
-      "outputs": ["dist/**", ".next/**", "!.next/cache/**", "public/dist/**"]
-    },
-    "backend#build": {
-      "dependsOn": ["@repo/test-config#build"],
-      "env": [
-        "DATABASE_URI",
-        "PAYLOAD_SECRET",
-        "GOOGLE_CLIENT_ID",
-        "GOOGLE_CLIENT_SECRET",
-        "JWT_SECRET",
-        "SMTP_HOST",
-        "SMTP_USER",
-        "SMTP_PASS"
-      ]
+      "outputs": ["dist/**", ".next/**", "public/dist/**"]
     },
     "pages:build": {
       "cache": true,


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes towards the related issue. Please also  include relevant context. List any dependencies that are required for this change. -->

This PR solves the problem where we were semi using our production as staging. I've separated the build scripts so that frontend and backend now both have dedicated staging and production environments. 

I've also created a composite server deployment action to avoid duplicating the same code. 

Server staging: https://server-staging.uoabadminton.co.nz
Server production: https://server.uoabadminton.co.nz
Client staging: https://staging.uoabadminton.co.nz
Client production: https://uoabadminton.co.nz

## Tasks behind the PR:

- [x] Created new fly compute
- [x] Setup cloudflare pages deployment for staging
- [x] Set secrets in Github
- [x] Setup google console for API to work with new URLs(uoabadminton.co.nz)
- [x] Refactor GitHub environments
- [x] Setup Cloudflare to point to fly backend servers

Fixes #517 

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Isn't really feasible to test

- [x] Manual testing (requires screenshots or videos)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added thorough tests that prove my fix is effective and that my feature works
- [x] I've requested a review from another user
