### PR TITLE
fix(navbar): correctly display navbar indicator state

### DIFF
--- a/packages/ui/src/components/Generic/NavigationBar/NavigationBarDesktop.tsx
+++ b/packages/ui/src/components/Generic/NavigationBar/NavigationBarDesktop.tsx
@@ -4,7 +4,7 @@ import { UabcLogo } from "@repo/ui/components/Icon"
 import { Box, HStack, Motion, Spacer } from "@yamada-ui/react"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
-import { useRef, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import type { NavigationBarProps } from "./NavigationBar"
 import { NavigationBarButton } from "./NavigationBarButton"
 import { NavigationBarUserMenu } from "./NavigationBarUserMenu"
@@ -23,15 +23,24 @@ export const NavigationBarDesktop = ({
   user,
 }: NavigationBarProps) => {
   const currentPath = usePathname()
+  useEffect(() => {
+    const initialIndex = navItems.findIndex((item) => item.url === currentPath)
+    setInitialIndex(initialIndex)
+    setHoveredIndex(initialIndex !== -1 ? initialIndex : null)
+    if (initialIndex !== -1) {
+      activeRef.current = itemRefs.current[initialIndex]
+    }
+  }, [currentPath, navItems])
 
   const fullName = `${user?.firstName} ${user?.lastName}`.trim()
   const src = typeof user?.image === "string" ? user?.image : user?.image?.thumbnailURL || ""
   const admin = user?.role === MembershipType.admin
 
-  const [hoveredIndex, setHoveredIndex] = useState<number | null>(() => {
+  const [initialIndex, setInitialIndex] = useState<number | null>(() => {
     const initialIndex = navItems.findIndex((item) => item.url === currentPath)
     return initialIndex !== -1 ? initialIndex : null
   })
+  const [hoveredIndex, setHoveredIndex] = useState<number | null>(initialIndex)
   const itemRefs = useRef<(HTMLAnchorElement | null)[]>([])
   const activeRef = useRef<HTMLAnchorElement | null>(null)
 
@@ -44,8 +53,13 @@ export const NavigationBarDesktop = ({
   }
 
   const clearHover = () => {
-    const initialIndex = navItems.findIndex((item) => item.url === currentPath)
-    setHoveredIndex(initialIndex !== -1 ? initialIndex : null)
+    setHoveredIndex(initialIndex)
+    activeRef.current = initialIndex ? itemRefs.current[initialIndex] : null
+  }
+
+  const clearIndicator = () => {
+    setHoveredIndex(null)
+    activeRef.current = null
   }
 
   return (
@@ -78,7 +92,14 @@ export const NavigationBarDesktop = ({
       zIndex={1001}
     >
       <HStack as={Motion} gap={0}>
-        <Box as={Link} borderRadius="50%" href="/" padding="sm" position="relative">
+        <Box
+          as={Link}
+          borderRadius="50%"
+          href="/"
+          onClick={clearIndicator}
+          padding="sm"
+          position="relative"
+        >
           <UabcLogo />
         </Box>
         <HStack as={Motion} data-testid="navbar-buttons-container" gap={0} onHoverEnd={clearHover}>
@@ -87,6 +108,7 @@ export const NavigationBarDesktop = ({
               <NavigationBarButton
                 hovering={hoveredIndex === index}
                 label={item.label}
+                onClick={() => setInitialIndex(index)}
                 ref={(el) => {
                   itemRefs.current[index] = el
                   if (item.url === currentPath && !activeRef.current) {
@@ -104,7 +126,11 @@ export const NavigationBarDesktop = ({
         {user ? (
           <NavigationBarUserMenu admin={admin} avatarProps={{ name: fullName, src: src }} />
         ) : (
-          <NavigationBarButton colorScheme="primary" {...rightSideSingleButton} />
+          <NavigationBarButton
+            colorScheme="primary"
+            onClick={clearIndicator}
+            {...rightSideSingleButton}
+          />
         )}
       </Box>
     </HStack>


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes towards the related issue. Please also  include relevant context. List any dependencies that are required for this change. -->

Introduces an indicator position state variable that is changed when navbar items are clicked. Adds an effect hook to set up the hovered index and initial index upon path change for redirections outside of nav items.

Fixes #603 

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Before:

https://github.com/user-attachments/assets/9086f91f-4adb-44c1-821d-12cc05cf4718

After:

https://github.com/user-attachments/assets/be4f90fd-6df9-4f86-8dda-d859ed9f1ab7


- [x] Manual testing (requires screenshots or videos)
- [ ] Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added thorough tests that prove my fix is effective and that my feature works
- [x] I've requested a review from another user
