### PR TITLE
feat(user-management): add cascade delete for user bookings with transaction support

### DIFF
--- a/apps/backend/src/app/api/admin/users/[id]/route.ts
+++ b/apps/backend/src/app/api/admin/users/[id]/route.ts
@@ -4,9 +4,9 @@ import { type NextRequest, NextResponse } from "next/server"
 import { NotFound } from "payload"
 import { ZodError } from "zod"
 import { Security } from "@/business-layer/middleware/Security"
-import UserDataService from "@/data-layer/services/UserDataService"
-import BookingDataService from "@/data-layer/services/BookingDataService"
 import { payload } from "@/data-layer/adapters/Payload"
+import BookingDataService from "@/data-layer/services/BookingDataService"
+import UserDataService from "@/data-layer/services/UserDataService"
 
 class UserRouteWrapper {
   /**
@@ -82,6 +82,8 @@ class UserRouteWrapper {
     { params }: { params: Promise<{ id: string; deleteRelatedBookings?: boolean }> },
   ) {
     const { id, deleteRelatedBookings } = await params
+
+    // This will only be undefined if deleteRelatedBookings is false OR transaction support is not enabled
     const cascadeDeleteTransactionID = await UserRouteWrapper.getTransactionId(
       !!deleteRelatedBookings,
     )

--- a/apps/backend/src/data-layer/services/BookingDataService.test.ts
+++ b/apps/backend/src/data-layer/services/BookingDataService.test.ts
@@ -136,4 +136,112 @@ describe("bookingDataService", () => {
       )
     })
   })
+  describe("deleteBookings", () => {
+    it("should delete multiple bookings successfully", async () => {
+      // Create multiple bookings first
+      const createdBooking1 = await bookingDataService.createBooking(bookingCreateMock)
+      const createdBooking2 = await bookingDataService.createBooking(bookingCreateMock2)
+
+      // Delete both bookings
+      const deletedBookings = await bookingDataService.deleteBookings([
+        createdBooking1.id,
+        createdBooking2.id,
+      ])
+
+      // Check if returned deleted bookings match the created ones
+      expect(deletedBookings).toEqual(expect.arrayContaining([createdBooking1, createdBooking2]))
+
+      // Verify bookings are actually deleted from database
+      await expect(() =>
+        payload.findByID({
+          collection: "booking",
+          id: createdBooking1.id,
+        }),
+      ).rejects.toThrowError("Not Found")
+
+      await expect(() =>
+        payload.findByID({
+          collection: "booking",
+          id: createdBooking2.id,
+        }),
+      ).rejects.toThrowError("Not Found")
+    })
+
+    it("should handle deletion of non-existent bookings", async () => {
+      const deletedBookings = await bookingDataService.deleteBookings([
+        "NonExistentId1",
+        "NonExistentId2",
+      ])
+
+      expect(deletedBookings).toEqual([])
+    })
+  })
+
+  describe("getBookingsByUserId", () => {
+    it("should find all bookings for a specific user", async () => {
+      // Create bookings with the same userId
+      const userId = "testUserId"
+      const bookingWithUser1 = {
+        ...bookingCreateMock,
+        user: userId,
+      }
+      const bookingWithUser2 = {
+        ...bookingCreateMock2,
+        user: userId,
+      }
+
+      const createdBooking1 = await bookingDataService.createBooking(bookingWithUser1)
+      const createdBooking2 = await bookingDataService.createBooking(bookingWithUser2)
+
+      // Get bookings for the user
+      const userBookings = await bookingDataService.getBookingsByUserId(userId)
+
+      expect(userBookings.docs).toHaveLength(2)
+      expect(userBookings.docs).toEqual(expect.arrayContaining([createdBooking1, createdBooking2]))
+    })
+
+    it("should return empty array when user has no bookings", async () => {
+      const userBookings = await bookingDataService.getBookingsByUserId("nonExistentUserId")
+
+      expect(userBookings.docs).toHaveLength(0)
+    })
+
+    it("should respect pagination parameters", async () => {
+      const userId = "testUserId2"
+      const bookingWithUser1 = {
+        ...bookingCreateMock,
+        user: userId,
+      }
+      const bookingWithUser2 = {
+        ...bookingCreateMock2,
+        user: userId,
+      }
+
+      await bookingDataService.createBooking(bookingWithUser1)
+      await bookingDataService.createBooking(bookingWithUser2)
+
+      // Test with limit of 1
+      const paginatedBookings = await bookingDataService.getBookingsByUserId(
+        userId,
+        undefined,
+        1,
+        1,
+      )
+
+      expect(paginatedBookings.docs).toHaveLength(1)
+      expect(paginatedBookings.hasNextPage).toBe(true)
+      expect(paginatedBookings.limit).toBe(1)
+      expect(paginatedBookings.page).toBe(1)
+    })
+
+    it("should use default pagination values when not provided", async () => {
+      const userId = "testUserId3"
+
+      const result = await bookingDataService.getBookingsByUserId(userId)
+
+      expect(result).toHaveProperty("docs")
+      expect(result).toHaveProperty("limit", 100)
+      expect(result).toHaveProperty("page", 1)
+    })
+  })
 })

--- a/apps/backend/src/data-layer/services/BookingDataService.ts
+++ b/apps/backend/src/data-layer/services/BookingDataService.ts
@@ -88,4 +88,53 @@ export default class BookingDataService {
       id,
     })
   }
+
+  /**
+   * Deletes multiple {@link Booking} documents by their IDs.
+   *
+   * @param ids An array of IDs of the {@link Booking} documents to delete.
+   * @param transactionID An optional transaction ID for the request, useful for tracing.
+   */
+  public async deleteBookings(ids: string[], transactionID?: string | number): Promise<Booking[]> {
+    const bulkDeletionResult = await payload.delete({
+      collection: "booking",
+      where: {
+        id: { in: ids },
+      },
+      req: {
+        transactionID,
+      },
+    })
+
+    return bulkDeletionResult.docs
+  }
+
+  /**
+   * Finds all {@link Booking} documents by a specific user ID.
+   *
+   * @param userId The ID of the user whose bookings to find.
+   * @param transactionID An optional transaction ID for the request, useful for tracing.
+   * @param limit The maximum number of documents to be returned, defaults to 100.
+   * @param page The specific page number to offset to, defaults to 1.
+   */
+  public async getBookingsByUserId(
+    userId: string,
+    transactionID?: string | number,
+    limit = 100,
+    page = 1,
+  ): Promise<PaginatedDocs<Booking>> {
+    return await payload.find({
+      collection: "booking",
+      where: {
+        user: {
+          equals: userId,
+        },
+      },
+      limit,
+      page,
+      req: {
+        transactionID,
+      },
+    })
+  }
 }

--- a/apps/backend/src/data-layer/services/UserDataService.ts
+++ b/apps/backend/src/data-layer/services/UserDataService.ts
@@ -89,12 +89,16 @@ export default class UserDataService {
    * Deletes a {@link User} document
    *
    * @param id The ID of the {@link User} to delete
+   * @param transactionID An optional transaction ID for the request, useful for tracking purposes
    * @returns The deleted {@link User} document if successful, otherwise throws a {@link NotFound} error
    */
-  public async deleteUser(id: string): Promise<User> {
+  public async deleteUser(id: string, transactionID?: string | number): Promise<User> {
     return await payload.delete({
       collection: "user",
       id,
+      req: {
+        transactionID,
+      },
     })
   }
 }

--- a/apps/backend/src/payload.config.ts
+++ b/apps/backend/src/payload.config.ts
@@ -66,6 +66,7 @@ export default buildConfig({
   db: mongooseAdapter({
     url: process.env.DATABASE_URI || "",
     allowIDOnCreate: process.env.NODE_ENV === "test",
+    transactionOptions: {},
   }),
   email:
     process.env.NODE_ENV === "production"


### PR DESCRIPTION
# Description

Added cascade delete functionality for users and their related bookings in the admin API. 

Key points for review:
1. Transaction handling implementation for atomic operations
2. New cascade delete parameter `deleteRelatedBookings` in DELETE endpoint
3. Error handling and rollback mechanism
4. New BookingDataService methods for bulk operations
5. Test coverage for success and failure scenarios

Fixes #551 (issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Integration tests written (requires checks to pass)
  - Success cases: Delete user with and without related bookings
  - Failure cases: Transaction rollback when errors occur
  - Transaction management: Proper begin/commit/rollback flow
  - BookingDataService: New methods for bulk operations and user-related queries

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added thorough tests that prove my fix is effective and that my feature works
- [x] I've requested a review from another user