### PR TITLE
fix(about): fix image width on about us

### DIFF
--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -1,6 +1,6 @@
 import { NuqsProvider } from "@repo/ui/components/Provider"
 import { Center, ColorModeScript } from "@yamada-ui/react"
-import type { Metadata } from "next"
+import type { Metadata, Viewport } from "next"
 import { Geist, Geist_Mono } from "next/font/google"
 import { Providers } from "@/app/providers"
 import { FooterServerSection } from "@/components/server/FooterServerSection"
@@ -15,6 +15,13 @@ const geistMono = Geist_Mono({
   subsets: ["latin"],
   variable: "--font-geist-mono",
 })
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  maximumScale: 1,
+  userScalable: false,
+}
 
 export const metadata: Metadata = {
   metadataBase: new URL(process.env.NEXT_PUBLIC_URL),
@@ -38,12 +45,6 @@ export const metadata: Metadata = {
   authors: [{ name: "2025 WDCC UABC Team" }],
   creator: "2025 WDCC UABC Team",
   publisher: "University of Auckland Badminton Club",
-  viewport: {
-    width: "device-width",
-    initialScale: 1,
-    maximumScale: 1,
-    userScalable: false,
-  },
   openGraph: {
     url: process.env.NEXT_PUBLIC_URL,
     siteName: "UABC",
@@ -75,7 +76,6 @@ export default function RootLayout({
               justifyContent={{ base: "flex-center", lg: "center" }}
               maxW="8xl"
               minH={{ base: "100dvh", lg: "unset" }}
-              overflowX="clip"
               placeSelf="center"
               px="md"
               py="lg"

--- a/apps/frontend/src/app/page.tsx
+++ b/apps/frontend/src/app/page.tsx
@@ -89,7 +89,7 @@ export default async function Home() {
             alt="Person smashing shuttlecock"
             borderTopRadius="3xl"
             h="full"
-            height={600}
+            height={1000}
             maxH="1150px"
             maxW="2000px"
             minH="480px"
@@ -99,7 +99,7 @@ export default async function Home() {
             position="relative"
             src="https://images.unsplash.com/photo-1599391398131-cd12dfc6c24e?q=80&w=1311&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
             w="full"
-            width={400}
+            width={1000}
             z={-1}
           />
           <Box

--- a/apps/frontend/src/app/page.tsx
+++ b/apps/frontend/src/app/page.tsx
@@ -84,19 +84,21 @@ export default async function Home() {
       </VStack>
       <QuickBook locationAndTimeOptions={locationAndTimeOptionsMock} />
       <Bleed as={Center} blockStart={{ base: "4xl", md: "3xl" }} inline="full">
-        <Box h="full" maxH="1150px" overflowY="clip" position="relative" w="full">
+        <Center h="full" maxH="1150px" overflowY="clip" position="relative" w="full">
           <Image
             alt="Person smashing shuttlecock"
             borderTopRadius="3xl"
-            h="100%"
+            h="full"
             height={600}
             maxH="1150px"
+            maxW="2000px"
             minH="480px"
             objectFit="cover"
             objectPosition="center"
+            placeSelf="center"
             position="relative"
             src="https://images.unsplash.com/photo-1599391398131-cd12dfc6c24e?q=80&w=1311&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
-            w="100%"
+            w="full"
             width={400}
             z={-1}
           />
@@ -127,7 +129,7 @@ export default async function Home() {
           >
             <LocationBubble {...mockBubble3} />
           </Box>
-        </Box>
+        </Center>
       </Bleed>
       <AboutUsServerSection />
       <FaqSection />


### PR DESCRIPTION
# Description

I've fixed how image wasn't going full screen width.
I have added a max width of 2000px to the image though, for wide monitors.

Fixes # (issue)

<img width="1920" height="1065" alt="image" src="https://github.com/user-attachments/assets/7126361e-91a0-45f9-9d00-0fbf56358d06" />

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)
- [ ] Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added thorough tests that prove my fix is effective and that my feature works
- [x] I've requested a review from another user
