### PR TITLE
create select a court

### DIFF
--- a/packages/ui/src/components/Composite/SelectACourt/SelectACourt.stories.tsx
+++ b/packages/ui/src/components/Composite/SelectACourt/SelectACourt.stories.tsx
@@ -1,0 +1,238 @@
+import type { Meta, StoryObj } from "@storybook/react"
+import { SelectACourt } from "./SelectACourt"
+
+/**
+ * Meta configuration for SelectACourt component stories.
+ *
+ * This component allows users to select booking sessions in a multi-step form flow.
+ * It supports both member and casual user types with different selection limits.
+ */
+const meta: Meta<typeof SelectACourt> = {
+  title: "Composite Components / SelectACourt",
+  component: SelectACourt,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component: `
+A session selection component for booking courts in a multi-step form flow.
+
+## Features
+- **Member/Casual variants**: Different selection limits (2 vs 1 sessions)
+- **Real-time validation**: Enforces selection limits automatically
+- **Form integration**: Uses React Hook Form for state management
+- **Navigation support**: Back/Next buttons for multi-step flows
+- **Responsive design**: Adapts to different screen sizes
+
+## Usage
+\`\`\`tsx
+import { SelectACourt } from "@repo/ui/components/Composite"
+
+<SelectACourt
+  variant="member"
+  sessions={availableSessions}
+  onSelect={handleSelection}
+  onNext={handleNextStep}
+/>
+\`\`\`
+        `,
+      },
+    },
+  },
+  argTypes: {
+    variant: {
+      description: "User type that determines selection behavior",
+      control: { type: "select" },
+      options: ["member", "casual"],
+      table: {
+        type: { summary: '"member" | "casual"' },
+        defaultValue: { summary: '"member"' },
+      },
+    },
+    sessions: {
+      description: "Array of available booking sessions",
+      control: { type: "object" },
+      table: {
+        type: { summary: "SessionItem[]" },
+        defaultValue: { summary: "[]" },
+      },
+    },
+    title: {
+      description: "Title displayed in the component header",
+      control: { type: "text" },
+      table: {
+        type: { summary: "string" },
+        defaultValue: { summary: '"Select a court"' },
+      },
+    },
+    onSelect: {
+      description: "Callback when sessions are selected/deselected",
+      action: "sessions selected",
+      table: {
+        type: { summary: "(value: string | string[] | undefined) => void" },
+      },
+    },
+    onBack: {
+      description: "Callback when back button is clicked",
+      action: "back clicked",
+      table: {
+        type: { summary: "() => void" },
+      },
+    },
+    onNext: {
+      description: "Callback when next button is clicked with form data",
+      action: "next clicked",
+      table: {
+        type: { summary: "(data: any) => void" },
+      },
+    },
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/**
+ * Default story showing member variant with multiple session options.
+ *
+ * Members can select up to 2 sessions and see attendee counts for both
+ * member and casual users.
+ */
+export const Default: Story = {
+  args: {
+    variant: "member",
+    title: "Select Your Sessions",
+    sessions: [
+      {
+        label: "Monday, 12th May",
+        memberAttendees: "32/35",
+        casualAttendees: "4/5",
+        value: "monday-session",
+        addon: "ABA",
+        description: "5:00 - 7:00 pm",
+      },
+      {
+        label: "Wednesday, 14th May",
+        memberAttendees: "28/35",
+        casualAttendees: "2/5",
+        value: "wednesday-session",
+        addon: "UoA Rec",
+        description: "7:30 - 9:30 pm",
+      },
+      {
+        label: "Thursday, 15th May",
+        memberAttendees: "25/30",
+        casualAttendees: "3/5",
+        value: "thursday-session",
+        addon: "Kings School",
+        description: "7:30 - 10:00 pm",
+      },
+      {
+        label: "Friday, 16th May",
+        memberAttendees: "30/35",
+        casualAttendees: "1/5",
+        value: "friday-session",
+        addon: "UoA Rec Centre",
+        description: "7:30 - 9:30 pm",
+      },
+      {
+        label: "Saturday, 17th May",
+        memberAttendees: "20/25",
+        casualAttendees: "2/3",
+        value: "saturday-session",
+        addon: "ABA",
+        description: "4:00 - 6:00 pm",
+      },
+    ],
+    onSelect: (value) => console.log("Selected sessions:", value),
+    onBack: () => console.log("Back button clicked"),
+    onNext: (data) => console.log("Next button clicked with data:", data),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: `
+This story demonstrates the member variant where users can select up to 2 sessions.
+
+**Key features:**
+- Shows attendee counts for both member and casual users
+- Allows multiple session selection (up to 2)
+- Displays real-time session availability
+- Integrates with form validation
+        `,
+      },
+    },
+  },
+}
+
+/**
+ * Casual user story showing single session selection.
+ *
+ * Casual users can only select 1 session and don't see member attendee counts.
+ */
+export const Casual: Story = {
+  args: {
+    variant: "casual",
+    title: "Choose Your Session",
+    sessions: [
+      {
+        label: "Monday, 12th May",
+        memberAttendees: "32/35",
+        casualAttendees: "4/5",
+        value: "monday-casual",
+        addon: "ABA",
+        description: "5:00 - 7:00 pm",
+      },
+      {
+        label: "Wednesday, 14th May",
+        memberAttendees: "28/35",
+        casualAttendees: "2/5",
+        value: "wednesday-casual",
+        addon: "UoA Rec",
+        description: "7:30 - 9:30 pm",
+      },
+      {
+        label: "Thursday, 15th May",
+        memberAttendees: "25/30",
+        casualAttendees: "3/5",
+        value: "thursday-casual",
+        addon: "Kings School",
+        description: "7:30 - 10:00 pm",
+      },
+      {
+        label: "Friday, 16th May",
+        memberAttendees: "30/35",
+        casualAttendees: "1/5",
+        value: "friday-casual",
+        addon: "UoA Rec Centre",
+        description: "7:30 - 9:30 pm",
+      },
+      {
+        label: "Saturday, 17th May",
+        memberAttendees: "20/25",
+        casualAttendees: "2/3",
+        value: "saturday-casual",
+        addon: "ABA",
+        description: "4:00 - 6:00 pm",
+      },
+    ],
+    onSelect: (value) => console.log("Selected session:", value),
+    onBack: () => console.log("Back button clicked"),
+    onNext: (data) => console.log("Next button clicked with data:", data),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: `
+This story demonstrates the casual variant where users can select only 1 session.
+
+**Key differences from member:**
+- Single session selection only
+- No member attendee counts displayed
+- Simplified interface for casual users
+- Different validation rules
+        `,
+      },
+    },
+  },
+}

--- a/packages/ui/src/components/Composite/SelectACourt/SelectACourt.tsx
+++ b/packages/ui/src/components/Composite/SelectACourt/SelectACourt.tsx
@@ -1,0 +1,286 @@
+"use client"
+
+import { BookingTimesCardGroup } from "@repo/ui/components/Generic"
+import { ShuttleIcon } from "@repo/ui/components/Icon"
+import { Button, Heading, IconWithText } from "@repo/ui/components/Primitive"
+import { ArrowLeftIcon, ArrowRightIcon } from "@yamada-ui/lucide"
+import { Card, CardBody, CardHeader, Center, HStack, IconButton } from "@yamada-ui/react"
+import { memo, useEffect, useMemo } from "react"
+import { useForm, useWatch } from "react-hook-form"
+
+/**
+ * The type of user variant for the booking session.
+ */
+type Variant = "member" | "casual"
+
+/**
+ * Represents a single booking session item.
+ */
+interface SessionItem {
+  /**
+   * The display label for the session (e.g., "Monday, 12th May").
+   */
+  label: string
+  /**
+   * The number of member attendees in format "current/max" (e.g., "32/35").
+   */
+  memberAttendees: string
+  /**
+   * The number of casual attendees in format "current/max" (e.g., "4/5").
+   */
+  casualAttendees: string
+  /**
+   * The unique identifier for the session.
+   */
+  value: string
+  /**
+   * The location or venue name for the session.
+   */
+  addon: string
+  /**
+   * The time description for the session (e.g., "7:30 - 10pm").
+   */
+  description: string
+  /**
+   * Whether the session is disabled for selection.
+   */
+  disabled?: boolean
+}
+
+/**
+ * Props for the SelectACourt component.
+ */
+export interface SelectACourtProps {
+  /**
+   * The user variant type that determines selection behavior.
+   * - "member": Can select up to 2 sessions
+   * - "casual": Can select only 1 session
+   *
+   * @default "member"
+   */
+  variant?: Variant
+
+  /**
+   * Callback function triggered when sessions are selected or deselected.
+   *
+   * @param value - The selected session value(s). For members: string[], for casual: string | undefined
+   */
+  onSelect?: (value: string | string[] | undefined) => void
+
+  /**
+   * Array of available booking sessions to display.
+   *
+   * @default []
+   */
+  sessions?: SessionItem[]
+
+  /**
+   * The title displayed in the component header.
+   *
+   * @default "Select a court"
+   */
+  title?: string
+
+  /**
+   * Callback function triggered when the back button is clicked.
+   * Used for navigation to the previous step in multi-step forms.
+   */
+  onBack?: () => void
+
+  /**
+   * Callback function triggered when the next button is clicked.
+   * Used for navigation to the next step in multi-step forms.
+   *
+   * @param data - The form data including selected sessions
+   */
+  onNext?: (data: any) => void
+}
+
+/**
+ * SelectACourt component for choosing booking sessions in a multi-step form flow.
+ *
+ * This component provides a card-based interface for selecting available booking sessions.
+ * It supports both member and casual user types with different selection limits and
+ * integrates with React Hook Form for form state management.
+ *
+ * @param props SelectACourt component properties
+ * @returns A session selection component
+ *
+ * @example
+ * // Basic usage with member variant
+ * <SelectACourt
+ *   variant="member"
+ *   sessions={[
+ *     {
+ *       label: "Monday, 12th May",
+ *       memberAttendees: "32/35",
+ *       casualAttendees: "4/5",
+ *       value: "booking-123",
+ *       addon: "UoA Hiwa Center",
+ *       description: "7:30 - 10pm"
+ *     }
+ *   ]}
+ *   onSelect={(value) => console.log("Selected:", value)}
+ * />
+ *
+ * @example
+ * // Multi-step form integration
+ * <SelectACourt
+ *   variant="casual"
+ *   title="Choose Your Session"
+ *   sessions={availableSessions}
+ *   onBack={() => setCurrentStep(currentStep - 1)}
+ *   onNext={(data) => {
+ *     setFormData(data)
+ *     setCurrentStep(currentStep + 1)
+ *   }}
+ *   onSelect={(value) => setSelectedSessions(value)}
+ * />
+ *
+ * @example
+ * // With custom session data
+ * const customSessions = [
+ *   {
+ *     label: "Wednesday, 14th May",
+ *     memberAttendees: "28/35",
+ *     casualAttendees: "2/5",
+ *     value: "wed-session",
+ *     addon: "Kings School",
+ *     description: "7:30 - 10:00 pm",
+ *     disabled: false
+ *   }
+ * ]
+ *
+ * <SelectACourt
+ *   sessions={customSessions}
+ *   onSelect={handleSessionSelection}
+ * />
+ */
+export const SelectACourt = memo<SelectACourtProps>(
+  ({ variant = "member", onSelect, sessions = [], title = "Select a court", onBack, onNext }) => {
+    const isMember = variant === "member"
+    const max = isMember ? 2 : 1
+
+    const {
+      control,
+      setValue,
+      handleSubmit,
+      formState: { isSubmitting },
+    } = useForm({
+      defaultValues: {
+        bookingTimes: isMember ? [] : "",
+      },
+    })
+
+    const watched = useWatch({ control, name: "bookingTimes" })
+
+    const selectionArray: string[] = isMember
+      ? (watched as string[])
+      : watched
+        ? [watched as string]
+        : []
+
+    useEffect(() => {
+      if (isMember && watched.length > max) {
+        setValue("bookingTimes", watched.slice(0, max), { shouldDirty: true })
+      }
+    }, [watched, isMember, max, setValue])
+
+    useEffect(() => {
+      onSelect?.(selectionArray)
+    }, [selectionArray, onSelect])
+
+    const processedSessions = useMemo(
+      () =>
+        sessions.map((s) => {
+          const selected = selectionArray.includes(s.value)
+          const capReached = selectionArray.length >= max
+          return {
+            ...s,
+            memberAttendees: isMember ? s.memberAttendees : undefined,
+            casualAttendees: isMember ? s.casualAttendees : undefined,
+            disabled: s.disabled || (isMember ? capReached && !selected : !!watched && !selected),
+          }
+        }),
+      [sessions, selectionArray, max, isMember, watched],
+    )
+
+    const handleNext = (data: any) => {
+      if (onNext) {
+        onNext(data)
+      } else {
+        console.log("Next step with data:", data)
+      }
+    }
+
+    return (
+      <Card
+        alignItems="center"
+        backdropBlur="15px"
+        backdropFilter="auto"
+        bg={["secondary.50", "secondary.800"]}
+        boxShadow="0px 1.5px 0px 0px rgba(0, 0, 0, 0.05), 0px 6px 6px 0px rgba(0, 0, 0, 0.05), 0px 15px 15px 0px rgba(0, 0, 0, 0.1)"
+        gap="md"
+        justifyContent="center"
+        layerStyle="gradientBorder"
+        px={{ base: "md", md: "xl" }}
+        py="lg"
+        rounded="3xl"
+      >
+        <CardHeader pt="0" w="full">
+          <HStack alignItems="center" display="grid" gridTemplateColumns="1fr auto 1fr" w="full">
+            <IconButton
+              aria-label="Back"
+              icon={<ArrowLeftIcon />}
+              justifySelf="start"
+              onClick={onBack}
+              size="lg"
+              variant="ghost"
+            />
+
+            <Heading.h2
+              color={{ base: "primary", md: "white" }}
+              fontSize={{ base: "2xl", md: "3xl" }}
+              fontWeight={{ base: "semibold", md: "medium" }}
+              textAlign="center"
+            >
+              {title}
+            </Heading.h2>
+
+            <IconWithText
+              icon={<ShuttleIcon />}
+              justifySelf="end"
+              label={`Sessions Left: ${max - selectionArray.length}`}
+            />
+          </HStack>
+        </CardHeader>
+        <CardBody p="0" w="full">
+          <form onSubmit={handleSubmit(handleNext)} style={{ width: "100%" }}>
+            <BookingTimesCardGroup
+              control={control}
+              display="grid"
+              gap={{ base: "sm", md: "md" }}
+              gridTemplateColumns={{ base: "1fr", sm: "repeat(2, 1fr)" }}
+              items={processedSessions} // Use the computed sessions from useMemo
+              name="bookingTimes"
+            />
+            <Center mt="md" py="md" w="full">
+              <Button
+                colorScheme="primary"
+                endIcon={<ArrowRightIcon />}
+                isDisabled={selectionArray.length === 0}
+                isLoading={isSubmitting}
+                size="lg"
+                type="submit"
+              >
+                Next
+              </Button>
+            </Center>
+          </form>
+        </CardBody>
+      </Card>
+    )
+  },
+)
+
+SelectACourt.displayName = "SelectACourt"

--- a/packages/ui/src/components/Composite/SelectACourt/index.ts
+++ b/packages/ui/src/components/Composite/SelectACourt/index.ts
@@ -1,0 +1,2 @@
+export type { SelectACourtProps } from "./SelectACourt"
+export { SelectACourt } from "./SelectACourt"


### PR DESCRIPTION
# Description

The SelectACourt component is a session booking interface for a badminton court system that allows users to select their preferred court sessions in a multi-step booking flow. It supports two user types: members (who can select up to 2 sessions) and casual users (limited to 1 session), with real-time display of attendee counts and availability. The component integrates with React Hook Form for state management, provides navigation controls (back/next buttons), and displays sessions in a responsive grid layout based on the actual court schedule (Monday at ABA, Wednesday at UoA Rec, Thursday at Kings School, Friday at UoA Rec Centre, and Saturday at ABA). Built with TypeScript for type safety, it includes comprehensive Storybook documentation and follows modern React patterns with proper accessibility support.

Fixes # (issue)

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [ ] Manual testing (requires screenshots or videos)
- [ ] Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [ ] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added thorough tests that prove my fix is effective and that my feature works
- [ ] I've requested a review from another user
