### PR TITLE
refactor(collections): add `useAsTitle` for better readability

### DIFF
--- a/apps/backend/src/data-layer/collections/Authentication.ts
+++ b/apps/backend/src/data-layer/collections/Authentication.ts
@@ -2,6 +2,9 @@ import type { CollectionConfig } from "payload"
 
 export const Authentication: CollectionConfig = {
   slug: "authentication",
+  admin: {
+    useAsTitle: "email",
+  },
   access: {},
   fields: [
     {

--- a/apps/backend/src/data-layer/collections/Event.ts
+++ b/apps/backend/src/data-layer/collections/Event.ts
@@ -2,6 +2,9 @@ import type { CollectionConfig } from "payload"
 
 export const Event: CollectionConfig = {
   slug: "event",
+  admin: {
+    useAsTitle: "title",
+  },
   fields: [
     {
       name: "title",

--- a/apps/backend/src/data-layer/collections/GameSessionSchedule.ts
+++ b/apps/backend/src/data-layer/collections/GameSessionSchedule.ts
@@ -4,6 +4,9 @@ import { createTimeField } from "@/data-layer/fields/date-time"
 
 export const GameSessionSchedule: CollectionConfig = {
   slug: "gameSessionSchedule",
+  admin: {
+    useAsTitle: "name",
+  },
   access: {},
   fields: [
     {

--- a/apps/backend/src/data-layer/collections/Media.ts
+++ b/apps/backend/src/data-layer/collections/Media.ts
@@ -2,6 +2,9 @@ import type { CollectionConfig } from "payload"
 
 export const Media: CollectionConfig = {
   slug: "media",
+  admin: {
+    useAsTitle: "alt",
+  },
   access: {
     read: () => true,
   },

--- a/apps/backend/src/data-layer/collections/Semester.ts
+++ b/apps/backend/src/data-layer/collections/Semester.ts
@@ -4,6 +4,9 @@ import { createTimeField } from "@/data-layer/fields/date-time"
 
 export const Semester: CollectionConfig = {
   slug: "semester",
+  admin: {
+    useAsTitle: "name",
+  },
   access: {},
   fields: [
     {

--- a/apps/backend/src/data-layer/collections/User.ts
+++ b/apps/backend/src/data-layer/collections/User.ts
@@ -99,6 +99,7 @@ export const User: CollectionConfig = {
       name: "remainingSessions",
       type: "number",
       required: false,
+      defaultValue: 0,
       admin: {
         description: "The number of remaining sessions the user has",
       },

--- a/apps/backend/src/data-layer/collections/User.ts
+++ b/apps/backend/src/data-layer/collections/User.ts
@@ -3,6 +3,9 @@ import type { CollectionConfig } from "payload"
 
 export const User: CollectionConfig = {
   slug: "user",
+  admin: {
+    useAsTitle: "email",
+  },
   fields: [
     {
       name: "firstName",


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes towards the related issue. Please also  include relevant context. List any dependencies that are required for this change. -->

Seeing a bunch of ids aren't very useful. 

BEFORE:

<img width="1841" height="131" alt="{EC2D04B9-70CC-4810-ABC5-2B89F148DF39}" src="https://github.com/user-attachments/assets/780fe3c5-7791-42ff-a6e0-478f58ad4fb9" />

AFTER:

<img width="1530" height="130" alt="{0FFD3315-8566-4E6C-9CA6-09BE8B1DFEE5}" src="https://github.com/user-attachments/assets/55470c82-fd64-465b-8171-42f1da4f4765" />

Also fixed the following by adding a `defaultValue`
<img width="199" height="81" alt="{4EF9F3AE-121C-4C09-903B-1CB898247884}" src="https://github.com/user-attachments/assets/53d136d6-f367-4aa7-a33b-29994d0f284c" />

Fixes #639 

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)
- [ ] Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added thorough tests that prove my fix is effective and that my feature works
- [x] I've requested a review from another user
