### PR TITLE
feat(bookings): implement booking open day and time checks

### DIFF
--- a/apps/backend/src/app/api/bookings/route.test.ts
+++ b/apps/backend/src/app/api/bookings/route.test.ts
@@ -4,7 +4,14 @@ import {
   MembershipType,
   PlayLevel,
 } from "@repo/shared"
-import { casualUserMock, memberUserMock, userCreateMock } from "@repo/shared/mocks"
+import {
+  casualUserMock,
+  gameSessionMock,
+  gameSessionMockBookingNotOpen,
+  memberUserMock,
+  semesterMock,
+  userCreateMock,
+} from "@repo/shared/mocks"
 import { getReasonPhrase, StatusCodes } from "http-status-codes"
 import { cookies } from "next/headers"
 import BookingDataService from "@/data-layer/services/BookingDataService"
@@ -88,6 +95,42 @@ describe("/api/bookings", async () => {
 
       expect(res.status).toBe(StatusCodes.FORBIDDEN)
       expect(await res.json()).toStrictEqual({ error: "No remaining sessions" })
+    })
+
+    it("should return a 403 if booking is attempted before bookingOpenDay and bookingOpenTime", async () => {
+      cookieStore.set(AUTH_COOKIE_NAME, memberToken)
+      const req = createMockNextRequest("/api/bookings", "POST", {
+        gameSession: gameSessionMockBookingNotOpen,
+        playerLevel: PlayLevel.beginner,
+      } satisfies CreateBookingRequestBodyType)
+      const res = await POST(req)
+      expect(res.status).toBe(StatusCodes.FORBIDDEN)
+      expect(await res.json()).toStrictEqual({ error: "Booking is not open yet for this semester" })
+    })
+
+    it("should return a 403 if booking a session scheduled before the semester's booking open time", async () => {
+      cookieStore.set(AUTH_COOKIE_NAME, memberToken)
+      const customSemester = {
+        ...semesterMock,
+        bookingOpenDay: "wednesday" as const,
+        bookingOpenTime: new Date(2025, 0, 1, 12, 0, 0).toISOString(),
+      }
+      const earlySession = {
+        ...gameSessionMock,
+        startTime: new Date(2025, 0, 1, 10, 0, 0).toISOString(),
+        semester: customSemester,
+      }
+      vi.setSystemTime(new Date(2025, 0, 1, 13, 0, 0))
+      const req = createMockNextRequest("/api/bookings", "POST", {
+        gameSession: earlySession,
+        playerLevel: PlayLevel.beginner,
+      } satisfies CreateBookingRequestBodyType)
+      const res = await POST(req)
+      expect(res.status).toBe(StatusCodes.FORBIDDEN)
+      expect(await res.json()).toStrictEqual({
+        error: "Cannot book a session scheduled before the semester's booking open time",
+      })
+      vi.useRealTimers()
     })
   })
 

--- a/apps/backend/src/data-layer/services/GameSessionDataService.ts
+++ b/apps/backend/src/data-layer/services/GameSessionDataService.ts
@@ -44,12 +44,14 @@ export default class GameSessionDataService {
    * Gets a {@link GameSession} by it's ID
    *
    * @param id the ID of the {@link GameSession} to fetch
+   * @param depth the population depth for related documents (default: 1)
    * @returns the {@link GameSession} document if it exists, otherwise throws a {@link NotFound} error
    */
-  public async getGameSessionById(id: string): Promise<GameSession> {
+  public async getGameSessionById(id: string, depth = 1): Promise<GameSession> {
     return await payload.findByID({
       collection: "gameSession",
       id,
+      depth,
     })
   }
 

--- a/packages/shared/src/mocks/GameSession.mock.ts
+++ b/packages/shared/src/mocks/GameSession.mock.ts
@@ -1,6 +1,6 @@
 import type { GameSession } from "../payload-types"
 import { gameSessionScheduleMock } from "./gameSessionSchedule.mock"
-import { semesterMock } from "./Semester.mock"
+import { semesterMock, semesterMockBookingNotOpen } from "./Semester.mock"
 
 export const gameSessionMock: GameSession = {
   id: "87efbe48887bc7ae09e305ed",
@@ -12,4 +12,9 @@ export const gameSessionMock: GameSession = {
   casualCapacity: 8,
   updatedAt: new Date(2025, 0, 1).toISOString(),
   createdAt: new Date(2025, 0, 1).toISOString(),
+}
+
+export const gameSessionMockBookingNotOpen: GameSession = {
+  ...gameSessionMock,
+  semester: semesterMockBookingNotOpen,
 }

--- a/packages/shared/src/mocks/Semester.mock.ts
+++ b/packages/shared/src/mocks/Semester.mock.ts
@@ -12,3 +12,9 @@ export const semesterMock: Semester = {
   updatedAt: new Date(2025, 0, 1).toISOString(),
   createdAt: new Date(2025, 0, 1).toISOString(),
 }
+
+export const semesterMockBookingNotOpen: Semester = {
+  ...semesterMock,
+  bookingOpenDay: "sunday",
+  bookingOpenTime: new Date(Date.now() + 1000 * 60 * 60 * 24).toISOString(),
+}


### PR DESCRIPTION
# Description

This PR enforces a restriction that prevents users from booking game sessions that are scheduled before the semester's booking open day and time.

Closes #606

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [ ] Manual testing (requires screenshots or videos)
- [x] Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added thorough tests that prove my fix is effective and that my feature works
- [x] I've requested a review from another user
