### PR TITLE
fix(auth): omit remainingSessions from JWT payload

### DIFF
--- a/apps/backend/src/app/api/auth/google/callback/route.test.ts
+++ b/apps/backend/src/app/api/auth/google/callback/route.test.ts
@@ -81,8 +81,12 @@ describe("GET /api/auth/google/callback", async () => {
     const authService = new AuthService()
     const data = authService.getData(token as string, JWTEncryptedUserSchema)
     const userMock = await userDataService.getUserByEmail(googleUserMock.email)
+    // Omit remainingSessions from userMock for JWT payload comparison
+    const userMockWithoutSessions = Object.fromEntries(
+      Object.entries(userMock).filter(([key]) => key !== "remainingSessions"),
+    )
     expect(data).toMatchObject({
-      user: userMock,
+      user: userMockWithoutSessions,
       accessToken: tokensMock.access_token,
     })
   })

--- a/apps/backend/src/app/api/auth/google/callback/route.test.ts
+++ b/apps/backend/src/app/api/auth/google/callback/route.test.ts
@@ -81,10 +81,7 @@ describe("GET /api/auth/google/callback", async () => {
     const authService = new AuthService()
     const data = authService.getData(token as string, JWTEncryptedUserSchema)
     const userMock = await userDataService.getUserByEmail(googleUserMock.email)
-    // Omit remainingSessions from userMock for JWT payload comparison
-    const userMockWithoutSessions = Object.fromEntries(
-      Object.entries(userMock).filter(([key]) => key !== "remainingSessions"),
-    )
+    const { remainingSessions: _omit, ...userMockWithoutSessions } = userMock
     expect(data).toMatchObject({
       user: userMockWithoutSessions,
       accessToken: tokensMock.access_token,

--- a/apps/backend/src/app/api/auth/google/callback/route.ts
+++ b/apps/backend/src/app/api/auth/google/callback/route.ts
@@ -125,7 +125,6 @@ export const GET = async (req: NextRequest) => {
    * JWT token including user info and the Google access token.
    * Expires in 1 hour (same duration as Google access token)
    */
-  // Omit remainingSessions from user before signing JWT (type-safe)
   const { remainingSessions: _omit, ...userWithoutSessions } = user
   const token = authService.signJWT(
     {

--- a/apps/backend/src/app/api/auth/google/callback/route.ts
+++ b/apps/backend/src/app/api/auth/google/callback/route.ts
@@ -125,9 +125,11 @@ export const GET = async (req: NextRequest) => {
    * JWT token including user info and the Google access token.
    * Expires in 1 hour (same duration as Google access token)
    */
+  // Omit remainingSessions from user before signing JWT (type-safe)
+  const { remainingSessions: _omit, ...userWithoutSessions } = user
   const token = authService.signJWT(
     {
-      user,
+      user: userWithoutSessions,
       accessToken: tokens.access_token,
     },
     { expiresIn: TOKEN_EXPIRY_TIME },

--- a/apps/backend/src/app/api/auth/login/route.test.ts
+++ b/apps/backend/src/app/api/auth/login/route.test.ts
@@ -43,7 +43,6 @@ describe("api/auth/login", () => {
 
       const data = authService.getData(token as string, JWTEncryptedUserSchema)
       const userMock = await userDataService.getUserByEmail(EMAIL_MOCK)
-      // Omit remainingSessions from userMock for JWT payload comparison
       const { remainingSessions: _omit, ...userMockWithoutSessions } = userMock
       expect(data).toMatchObject({
         user: userMockWithoutSessions,

--- a/apps/backend/src/app/api/auth/login/route.test.ts
+++ b/apps/backend/src/app/api/auth/login/route.test.ts
@@ -43,8 +43,12 @@ describe("api/auth/login", () => {
 
       const data = authService.getData(token as string, JWTEncryptedUserSchema)
       const userMock = await userDataService.getUserByEmail(EMAIL_MOCK)
+      // Omit remainingSessions from userMock for JWT payload comparison
+      const userMockWithoutSessions = Object.fromEntries(
+        Object.entries(userMock).filter(([key]) => key !== "remainingSessions"),
+      )
       expect(data).toMatchObject({
-        user: userMock,
+        user: userMockWithoutSessions,
       })
     })
 

--- a/apps/backend/src/app/api/auth/login/route.test.ts
+++ b/apps/backend/src/app/api/auth/login/route.test.ts
@@ -44,9 +44,7 @@ describe("api/auth/login", () => {
       const data = authService.getData(token as string, JWTEncryptedUserSchema)
       const userMock = await userDataService.getUserByEmail(EMAIL_MOCK)
       // Omit remainingSessions from userMock for JWT payload comparison
-      const userMockWithoutSessions = Object.fromEntries(
-        Object.entries(userMock).filter(([key]) => key !== "remainingSessions"),
-      )
+      const { remainingSessions: _omit, ...userMockWithoutSessions } = userMock
       expect(data).toMatchObject({
         user: userMockWithoutSessions,
       })

--- a/apps/backend/src/app/api/auth/login/route.ts
+++ b/apps/backend/src/app/api/auth/login/route.ts
@@ -44,7 +44,9 @@ export const POST = async (req: NextRequest) => {
     )
   }
 
-  const token = authService.signJWT({ user }, { expiresIn: TOKEN_EXPIRY_TIME })
+  // Omit remainingSessions from user before signing JWT (type-safe)
+  const { remainingSessions: _omit, ...userWithoutSessions } = user
+  const token = authService.signJWT({ user: userWithoutSessions }, { expiresIn: TOKEN_EXPIRY_TIME })
   const response = NextResponse.json(
     {
       data: token,


### PR DESCRIPTION
# Description

- Omit `remainingSessions` from the JWT payload for all authentication flows.
- Ensures JWTs do not become stale due to session count changes.
- Updates tests to match new JWT payload structure.
- No changes to user schema or business logic; only JWT construction is affected.

- Closes #584

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [ ] Manual testing (requires screenshots or videos)
- [x] Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added thorough tests that prove my fix is effective and that my feature works
- [x] I've requested a review from another user
