### PR TITLE
feat(profile-booking-panel): disable delete button for casual and member users

### DIFF
--- a/apps/frontend/src/components/client/user/ProfileSection.tsx
+++ b/apps/frontend/src/components/client/user/ProfileSection.tsx
@@ -29,7 +29,11 @@ export const ProfileSection = memo(({ auth }: { auth: AuthContextValue }) => {
           {isBookingsLoading || !user ? (
             <ProfileBookingPanelSkeleton />
           ) : (
-            <ProfileBookingPanel bookings={bookings?.data ?? []} error={isBookingsError} />
+            <ProfileBookingPanel
+              bookings={bookings?.data ?? []}
+              error={isBookingsError}
+              user={user}
+            />
           )}
         </GridItem>
       </Grid>

--- a/packages/ui/src/components/Composite/ProfileBookingPanel/ProfileBookingPanel.stories.tsx
+++ b/packages/ui/src/components/Composite/ProfileBookingPanel/ProfileBookingPanel.stories.tsx
@@ -1,0 +1,50 @@
+import { adminUserMock, bookingsMock, casualUserMock, memberUserMock } from "@repo/shared/mocks"
+import type { Meta, StoryObj } from "@storybook/react"
+import { ProfileBookingPanel } from "./ProfileBookingPanel"
+
+const meta: Meta<typeof ProfileBookingPanel> = {
+  title: "Composite Components / ProfileBookingPanel",
+  component: ProfileBookingPanel,
+  parameters: {
+    layout: "centered",
+  },
+}
+export default meta
+
+type Story = StoryObj<typeof ProfileBookingPanel>
+
+export const CasualUser: Story = {
+  args: {
+    bookings: bookingsMock,
+    user: casualUserMock,
+  },
+}
+
+export const MemberUser: Story = {
+  args: {
+    bookings: bookingsMock,
+    user: memberUserMock,
+  },
+}
+
+export const AdminUser: Story = {
+  args: {
+    bookings: bookingsMock,
+    user: adminUserMock,
+  },
+}
+
+export const ErrorState: Story = {
+  args: {
+    bookings: [],
+    user: adminUserMock,
+    error: true,
+  },
+}
+
+export const EmptyState: Story = {
+  args: {
+    bookings: [],
+    user: adminUserMock,
+  },
+}

--- a/packages/ui/src/components/Composite/ProfileBookingPanel/ProfileBookingPanel.test.tsx
+++ b/packages/ui/src/components/Composite/ProfileBookingPanel/ProfileBookingPanel.test.tsx
@@ -1,0 +1,49 @@
+import { adminUserMock, bookingsMock, casualUserMock, memberUserMock } from "@repo/shared/mocks"
+import { render, screen } from "@repo/ui/test-utils"
+import { ProfileBookingPanel } from "./ProfileBookingPanel"
+
+describe("<ProfileBookingPanel />", () => {
+  it("renders all bookings", () => {
+    render(<ProfileBookingPanel bookings={bookingsMock} user={adminUserMock} />)
+    expect(screen.getAllByTestId("booking-card")).toHaveLength(bookingsMock.length)
+  })
+
+  it("disables delete and shows tooltip for casual user", async () => {
+    render(<ProfileBookingPanel bookings={bookingsMock} user={casualUserMock} />)
+    const menuButtons = screen.getAllByRole("button", { name: /more options/i })
+    await menuButtons[0].click()
+    const deleteItem = await screen.findByText("Delete")
+    expect(deleteItem).toHaveAttribute("aria-disabled", "true")
+    expect(screen.getByText("Please contact an admin to delete your booking")).toBeInTheDocument()
+  })
+
+  it("disables delete and shows tooltip for member user", async () => {
+    render(<ProfileBookingPanel bookings={bookingsMock} user={memberUserMock} />)
+    const menuButtons = screen.getAllByRole("button", { name: /more options/i })
+    await menuButtons[0].click()
+    const deleteItem = await screen.findByText("Delete")
+    expect(deleteItem).toHaveAttribute("aria-disabled", "true")
+    expect(screen.getByText("Please contact an admin to delete your booking")).toBeInTheDocument()
+  })
+
+  it("enables delete and does not show tooltip for admin user", async () => {
+    render(<ProfileBookingPanel bookings={bookingsMock} user={adminUserMock} />)
+    const menuButtons = screen.getAllByRole("button", { name: /more options/i })
+    await menuButtons[0].click()
+    const deleteItem = await screen.findByText("Delete")
+    expect(deleteItem).not.toHaveAttribute("aria-disabled", "true")
+    expect(
+      screen.queryByText("Please contact an admin to delete your booking"),
+    ).not.toBeInTheDocument()
+  })
+
+  it("renders empty state when no bookings", () => {
+    render(<ProfileBookingPanel bookings={[]} user={adminUserMock} />)
+    expect(screen.getByText("No bookings found")).toBeInTheDocument()
+  })
+
+  it("renders error state when error is true", () => {
+    render(<ProfileBookingPanel bookings={[]} error user={adminUserMock} />)
+    expect(screen.getByText("Failed to load bookings")).toBeInTheDocument()
+  })
+})

--- a/packages/ui/src/components/Composite/ProfileBookingPanel/ProfileBookingPanel.test.tsx
+++ b/packages/ui/src/components/Composite/ProfileBookingPanel/ProfileBookingPanel.test.tsx
@@ -9,27 +9,27 @@ describe("<ProfileBookingPanel />", () => {
   })
 
   it("disables delete and shows tooltip for casual user", async () => {
-    render(<ProfileBookingPanel bookings={bookingsMock} user={casualUserMock} />)
+    const { user } = render(<ProfileBookingPanel bookings={bookingsMock} user={casualUserMock} />)
     const menuButtons = screen.getAllByRole("button", { name: /more options/i })
-    await menuButtons[0].click()
+    user?.click(menuButtons[0])
     const deleteItem = await screen.findByText("Delete")
     expect(deleteItem).toHaveAttribute("aria-disabled", "true")
     expect(screen.getByText("Please contact an admin to delete your booking")).toBeInTheDocument()
   })
 
   it("disables delete and shows tooltip for member user", async () => {
-    render(<ProfileBookingPanel bookings={bookingsMock} user={memberUserMock} />)
+    const { user } = render(<ProfileBookingPanel bookings={bookingsMock} user={memberUserMock} />)
     const menuButtons = screen.getAllByRole("button", { name: /more options/i })
-    await menuButtons[0].click()
+    user?.click(menuButtons[0])
     const deleteItem = await screen.findByText("Delete")
     expect(deleteItem).toHaveAttribute("aria-disabled", "true")
     expect(screen.getByText("Please contact an admin to delete your booking")).toBeInTheDocument()
   })
 
   it("enables delete and does not show tooltip for admin user", async () => {
-    render(<ProfileBookingPanel bookings={bookingsMock} user={adminUserMock} />)
+    const { user } = render(<ProfileBookingPanel bookings={bookingsMock} user={adminUserMock} />)
     const menuButtons = screen.getAllByRole("button", { name: /more options/i })
-    await menuButtons[0].click()
+    user?.click(menuButtons[0])
     const deleteItem = await screen.findByText("Delete")
     expect(deleteItem).not.toHaveAttribute("aria-disabled", "true")
     expect(

--- a/packages/ui/src/components/Composite/ProfileBookingPanel/ProfileBookingPanel.tsx
+++ b/packages/ui/src/components/Composite/ProfileBookingPanel/ProfileBookingPanel.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { MembershipType } from "@repo/shared"
 import type { Booking, GameSession, GameSessionSchedule } from "@repo/shared/payload-types"
 import { CircleAlertIcon } from "@yamada-ui/lucide"
 import { EmptyState, For, type StackProps, VStack } from "@yamada-ui/react"
@@ -26,7 +27,7 @@ export interface ProfileBookingPanelProps extends StackProps {
   /**
    * The user viewing the bookings (for role-based UI)
    */
-  user?: { role: string }
+  user?: { role: MembershipType }
 }
 
 /**
@@ -40,7 +41,8 @@ export interface ProfileBookingPanelProps extends StackProps {
  */
 export const ProfileBookingPanel: FC<ProfileBookingPanelProps> = memo(
   ({ bookings, error, user, ...props }) => {
-    const isDeleteDisabled = user && (user.role === "casual" || user.role === "member")
+    const isDeleteDisabled =
+      user && (user.role === MembershipType.casual || user.role === MembershipType.member)
 
     return (
       <VStack

--- a/packages/ui/src/components/Composite/ProfileBookingPanel/ProfileBookingPanel.tsx
+++ b/packages/ui/src/components/Composite/ProfileBookingPanel/ProfileBookingPanel.tsx
@@ -23,6 +23,10 @@ export interface ProfileBookingPanelProps extends StackProps {
    * Whether there was an error fetching bookings
    */
   error?: boolean
+  /**
+   * The user viewing the bookings (for role-based UI)
+   */
+  user?: { role: string }
 }
 
 /**
@@ -35,7 +39,9 @@ export interface ProfileBookingPanelProps extends StackProps {
  * <ProfileBookingPanel bookings={mockBookings} />
  */
 export const ProfileBookingPanel: FC<ProfileBookingPanelProps> = memo(
-  ({ bookings, error, ...props }) => {
+  ({ bookings, error, user, ...props }) => {
+    const isDeleteDisabled = user && (user.role === "casual" || user.role === "member")
+
     return (
       <VStack
         bg={["secondary.50", "secondary.900"]}
@@ -84,7 +90,15 @@ export const ProfileBookingPanel: FC<ProfileBookingPanelProps> = memo(
                 location={name ?? (gameSessionSchedule as GameSessionSchedule).name}
                 menuItems={[
                   { label: "Edit", onClick: () => alert("Edit clicked"), color: "primary" },
-                  { label: "Delete", onClick: () => alert("Delete clicked"), color: "danger" },
+                  {
+                    label: "Delete",
+                    onClick: () => alert("Delete clicked"),
+                    color: "danger",
+                    disabled: isDeleteDisabled,
+                    tooltipLabel: isDeleteDisabled
+                      ? "Please contact an admin to delete your booking"
+                      : undefined,
+                  },
                 ]}
                 startTime={startTime}
               />

--- a/packages/ui/src/components/Composite/ProfileBookingPanel/ProfileBookingPanel.tsx
+++ b/packages/ui/src/components/Composite/ProfileBookingPanel/ProfileBookingPanel.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { MembershipType } from "@repo/shared"
-import type { Booking, GameSession, GameSessionSchedule } from "@repo/shared/payload-types"
+import type { Booking, GameSession, GameSessionSchedule, User } from "@repo/shared/payload-types"
 import { CircleAlertIcon } from "@yamada-ui/lucide"
 import { EmptyState, For, type StackProps, VStack } from "@yamada-ui/react"
 import { type FC, memo } from "react"
@@ -27,7 +27,7 @@ export interface ProfileBookingPanelProps extends StackProps {
   /**
    * The user viewing the bookings (for role-based UI)
    */
-  user?: { role: MembershipType }
+  user?: User
 }
 
 /**

--- a/packages/ui/src/components/Generic/BookingCard/BookingCard.test.tsx
+++ b/packages/ui/src/components/Generic/BookingCard/BookingCard.test.tsx
@@ -62,4 +62,16 @@ describe("<BookingCard />", () => {
     await user.click(deleteItem)
     expect(defaultProps.menuItems[1].onClick).toHaveBeenCalled()
   })
+
+  it("should disable the Delete menu item when disabled is true", async () => {
+    const menuItems = [
+      { label: "Edit", onClick: vi.fn(), color: "primary" },
+      { label: "Delete", onClick: vi.fn(), color: "danger", disabled: true },
+    ]
+    const { user } = render(<BookingCard {...defaultProps} menuItems={menuItems} />)
+    const menuButton = screen.getByRole("button", { name: /more options/i })
+    user.click(menuButton)
+    const deleteItem = await screen.findByText("Delete")
+    expect(deleteItem).toHaveAttribute("aria-disabled", "true")
+  })
 })

--- a/packages/ui/src/components/Generic/BookingCard/BookingCard.test.tsx
+++ b/packages/ui/src/components/Generic/BookingCard/BookingCard.test.tsx
@@ -47,8 +47,6 @@ describe("<BookingCard />", () => {
       ),
     ).toBeInTheDocument()
     expect(screen.getByAltText(defaultProps.imageProps.alt)).toBeInTheDocument()
-    expect(screen.getByText("Edit")).toBeInTheDocument()
-    expect(screen.getByText("Delete")).toBeInTheDocument()
   })
 
   it("should call menu item onClick when clicked", async () => {
@@ -58,6 +56,7 @@ describe("<BookingCard />", () => {
     const editItem = await screen.findByText("Edit")
     await user.click(editItem)
     expect(defaultProps.menuItems[0].onClick).toHaveBeenCalled()
+    await user.click(menuButton)
     const deleteItem = await screen.findByText("Delete")
     await user.click(deleteItem)
     expect(defaultProps.menuItems[1].onClick).toHaveBeenCalled()

--- a/packages/ui/src/components/Generic/BookingCard/BookingCard.tsx
+++ b/packages/ui/src/components/Generic/BookingCard/BookingCard.tsx
@@ -24,6 +24,7 @@ import {
   Portal,
   type PortalProps,
   Text,
+  Tooltip,
   VStack,
 } from "@yamada-ui/react"
 import dayjs from "dayjs"
@@ -38,6 +39,7 @@ const NZ_TIMEZONE = "Pacific/Auckland"
 
 type MenuItemType = MenuItemProps & {
   label: string
+  tooltipLabel?: string
 }
 
 /**
@@ -191,11 +193,20 @@ export const BookingCard = memo(
               />
               <Portal {...portalProps}>
                 <MenuList {...menuListProps}>
-                  {menuItems.map(({ label, ...item }) => (
-                    <MenuItem key={label} {...menuItemProps} {...item}>
-                      {label}
-                    </MenuItem>
-                  ))}
+                  {menuItems.map(({ label, tooltipLabel, ...item }) => {
+                    const menuItem = (
+                      <MenuItem key={label} {...menuItemProps} {...item}>
+                        {label}
+                      </MenuItem>
+                    )
+                    return tooltipLabel ? (
+                      <Tooltip key={label} label={tooltipLabel} withPortal>
+                        {menuItem}
+                      </Tooltip>
+                    ) : (
+                      menuItem
+                    )
+                  })}
                 </MenuList>
               </Portal>
             </Menu>

--- a/packages/ui/src/components/Generic/BookingCard/BookingCard.tsx
+++ b/packages/ui/src/components/Generic/BookingCard/BookingCard.tsx
@@ -178,7 +178,7 @@ export const BookingCard = memo(
         </VStack>
         {menuItems && menuItems.length > 0 && (
           <CardFooter pb="0" px="0">
-            <Menu {...menuProps}>
+            <Menu lazy {...menuProps}>
               <MenuButton
                 aria-label="More options"
                 as={IconButton}


### PR DESCRIPTION
# Description

- The delete button in the bookings panel is now disabled for users with the 'casual' or 'member' role.
- The user object is passed down to ProfileBookingPanel for role-based UI logic.
- Added a test to ensure the BookingCard disables the delete menu item when required.

- Closes #638

<img width="585" height="401" alt="image" src="https://github.com/user-attachments/assets/454273c3-6eaf-46f3-95f0-82013ec81655" />

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)
- [ ] Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added thorough tests that prove my fix is effective and that my feature works
- [x] I've requested a review from another user
