### PR TITLE
fix(mongo, test, setup): fix mongodb test making many temp folders

### DIFF
--- a/packages/test-config/src/setups/db.ts
+++ b/packages/test-config/src/setups/db.ts
@@ -1,0 +1,23 @@
+import { MongoMemoryServer } from "mongodb-memory-server"
+
+let mongod: MongoMemoryServer | undefined
+
+export const create = async (): Promise<MongoMemoryServer> => {
+  if (mongod) {
+    return mongod
+  }
+  mongod = await MongoMemoryServer.create()
+  return mongod
+}
+
+export const close = async (): Promise<void> => {
+  await mongod?.stop()
+  mongod = undefined
+}
+
+export const getUri = async (): Promise<string> => {
+  if (!mongod) {
+    return (await create()).getUri()
+  }
+  return mongod.getUri()
+}

--- a/packages/test-config/src/setups/mongodb-setup.ts
+++ b/packages/test-config/src/setups/mongodb-setup.ts
@@ -1,5 +1,12 @@
-import { MongoMemoryServer } from "mongodb-memory-server"
-export const mongod = await MongoMemoryServer.create()
+import * as db from "./db"
+
+beforeAll(async () => {
+  await db.create()
+})
+
+afterAll(async () => {
+  await db.close()
+})
 
 process.env.PAYLOAD_SECRET = "I love uabc!!!!"
-process.env.DATABASE_URI = mongod.getUri()
+process.env.DATABASE_URI = await db.getUri()


### PR DESCRIPTION
# Description

This fixes mongo memory server creating many temp folders during test.
I think the issue was, every test the mongodb-setup was being called and it was creating a new mongo-db instance every single test without clearing previous one.

Closes #670

<img width="1015" height="359" alt="image" src="https://github.com/user-attachments/assets/5aea44cf-ccec-46af-81e7-c205b1f70ab9" />

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)
- [ ] Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added thorough tests that prove my fix is effective and that my feature works
- [ ] I've requested a review from another user
