### PR TITLE
fix(bookings): ensure booking open date calculations use UTC consistently

### DIFF
--- a/apps/backend/src/app/api/bookings/route.ts
+++ b/apps/backend/src/app/api/bookings/route.ts
@@ -32,7 +32,6 @@ class RouteWrapper {
       const openDay = (gameSession.semester as Semester).bookingOpenDay
       const openTime = new Date((gameSession.semester as Semester).bookingOpenTime)
 
-      // Calculate the booking open date
       const openDate = calculateOpenDate(sessionStartTime, openDay as Weekday, openTime)
 
       const now = new Date()

--- a/packages/shared/src/utils/date.ts
+++ b/packages/shared/src/utils/date.ts
@@ -23,12 +23,17 @@ export function getDaysBetweenWeekdays(fromDay: Weekday, toDay: Weekday): number
  */
 export function calculateOpenDate(startTime: Date, openDay: Weekday, openTime: Date): Date {
   const openDate = new Date(startTime)
-  const dayIndex = startTime.getDay()
+  const dayIndex = startTime.getUTCDay()
   const day = Object.values(Weekday)[dayIndex] as Weekday
   const daysToSubtract = getDaysBetweenWeekdays(openDay, day)
 
-  openDate.setDate(startTime.getDate() - daysToSubtract)
-  openDate.setHours(openTime.getHours(), openTime.getMinutes(), openTime.getSeconds(), 0)
+  openDate.setUTCDate(startTime.getUTCDate() - daysToSubtract)
+  openDate.setUTCHours(
+    openTime.getUTCHours(),
+    openTime.getUTCMinutes(),
+    openTime.getUTCSeconds(),
+    0,
+  )
 
   return openDate
 }


### PR DESCRIPTION
# Description

I have made the date related utilities to properly use UTC.

- Closes #675

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [ ] Manual testing (requires screenshots or videos)
- [x] Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added thorough tests that prove my fix is effective and that my feature works
- [x] I've requested a review from another user
