### PR TITLE
feat(game-sessions): implement admin POST endpoint to create a GameSession

### DIFF
--- a/apps/backend/src/app/api/admin/game-sessions/route.test.ts
+++ b/apps/backend/src/app/api/admin/game-sessions/route.test.ts
@@ -12,10 +12,6 @@ describe("api/admin/game-sessions", async () => {
   const cookieStore = await cookies()
 
   describe("POST", () => {
-    beforeEach(() => {
-      cookieStore.set(AUTH_COOKIE_NAME, adminToken)
-    })
-
     it("should return a 401 status if user is a member", async () => {
       cookieStore.set(AUTH_COOKIE_NAME, memberToken)
 
@@ -35,6 +31,8 @@ describe("api/admin/game-sessions", async () => {
     })
 
     it("should allow admins to create a game session", async () => {
+      cookieStore.set(AUTH_COOKIE_NAME, adminToken)
+
       const res = await POST(createMockNextRequest("", "POST", gameSessionCreateMock))
 
       expect(res.status).toBe(StatusCodes.CREATED)
@@ -44,6 +42,8 @@ describe("api/admin/game-sessions", async () => {
     })
 
     it("should return a 400 status when request body is invalid", async () => {
+      cookieStore.set(AUTH_COOKIE_NAME, adminToken)
+
       const res = await POST(
         createMockNextRequest("", "POST", {
           ...gameSessionCreateMock,
@@ -58,6 +58,8 @@ describe("api/admin/game-sessions", async () => {
     })
 
     it("should raise an error if invalid date is used", async () => {
+      cookieStore.set(AUTH_COOKIE_NAME, adminToken)
+
       const res = await POST(
         createMockNextRequest("", "POST", {
           ...gameSessionCreateMock,
@@ -74,6 +76,8 @@ describe("api/admin/game-sessions", async () => {
     })
 
     it("should return a 500 for an internal server error", async () => {
+      cookieStore.set(AUTH_COOKIE_NAME, adminToken)
+
       vi.spyOn(GameSessionDataService.prototype, "createGameSession").mockRejectedValueOnce(
         new Error("Database error"),
       )

--- a/apps/backend/src/app/api/admin/game-sessions/route.test.ts
+++ b/apps/backend/src/app/api/admin/game-sessions/route.test.ts
@@ -1,0 +1,88 @@
+import { AUTH_COOKIE_NAME } from "@repo/shared"
+import { StatusCodes } from "http-status-codes"
+import { cookies } from "next/headers"
+import GameSessionDataService from "@/data-layer/services/GameSessionDataService"
+import { createMockNextRequest } from "@/test-config/backend-utils"
+import { gameSessionCreateMock } from "@/test-config/mocks/GameSession.mock"
+import { adminToken, casualToken, memberToken } from "@/test-config/vitest.setup"
+import { POST } from "./route"
+
+describe("api/admin/game-sessions", async () => {
+  const gameSessionDataService = new GameSessionDataService()
+  const cookieStore = await cookies()
+
+  describe("POST", () => {
+    beforeEach(() => {
+      cookieStore.set(AUTH_COOKIE_NAME, adminToken)
+    })
+
+    it("should return a 401 status if user is a member", async () => {
+      cookieStore.set(AUTH_COOKIE_NAME, memberToken)
+
+      const res = await POST(createMockNextRequest("", "POST", gameSessionCreateMock))
+
+      expect(res.status).toBe(StatusCodes.UNAUTHORIZED)
+      expect(await res.json()).toStrictEqual({ error: "No scope" })
+    })
+
+    it("should return a 401 status if user is a casual", async () => {
+      cookieStore.set(AUTH_COOKIE_NAME, casualToken)
+
+      const res = await POST(createMockNextRequest("", "POST", gameSessionCreateMock))
+
+      expect(res.status).toBe(StatusCodes.UNAUTHORIZED)
+      expect(await res.json()).toStrictEqual({ error: "No scope" })
+    })
+
+    it("should allow admins to create a game session", async () => {
+      const res = await POST(createMockNextRequest("", "POST", gameSessionCreateMock))
+
+      expect(res.status).toBe(StatusCodes.CREATED)
+      const data = (await res.json()).data
+      const fetchedGameSession = await gameSessionDataService.getGameSessionById(data.id)
+      expect(data).toEqual(fetchedGameSession)
+    })
+
+    it("should return a 400 status when request body is invalid", async () => {
+      const res = await POST(
+        createMockNextRequest("", "POST", {
+          ...gameSessionCreateMock,
+          capacity: undefined,
+        }),
+      )
+
+      expect(res.status).toBe(StatusCodes.BAD_REQUEST)
+      const json = await res.json()
+      expect(json.error).toEqual("Invalid request body")
+      expect(json.details.fieldErrors.capacity[0]).toEqual("Required")
+    })
+
+    it("should raise an error if invalid date is used", async () => {
+      const res = await POST(
+        createMockNextRequest("", "POST", {
+          ...gameSessionCreateMock,
+          startTime: "NOT A DATE",
+        }),
+      )
+
+      expect(res.status).toBe(StatusCodes.BAD_REQUEST)
+      const json = await res.json()
+      expect(json.error).toEqual("Invalid request body")
+      expect(json.details.fieldErrors.startTime[0]).toEqual(
+        "Invalid date format, should be in ISO 8601 format",
+      )
+    })
+
+    it("should return a 500 for an internal server error", async () => {
+      vi.spyOn(GameSessionDataService.prototype, "createGameSession").mockRejectedValueOnce(
+        new Error("Database error"),
+      )
+
+      const res = await POST(createMockNextRequest("", "POST", gameSessionCreateMock))
+
+      expect(res.status).toBe(StatusCodes.INTERNAL_SERVER_ERROR)
+      const json = await res.json()
+      expect(json.error).toEqual("Internal Server Error")
+    })
+  })
+})

--- a/apps/backend/src/app/api/admin/game-sessions/route.ts
+++ b/apps/backend/src/app/api/admin/game-sessions/route.ts
@@ -3,9 +3,16 @@ import { getReasonPhrase, StatusCodes } from "http-status-codes"
 import { type NextRequest, NextResponse } from "next/server"
 import { ZodError } from "zod"
 import { Security } from "@/business-layer/middleware/Security"
+import type { GameSession } from "@/data-layer/collections/GameSession"
 import GameSessionDataService from "@/data-layer/services/GameSessionDataService"
 
 class GameSessionRouteWrapper {
+  /**
+   * POST Method to create a new game session.
+   *
+   * @param req The request object containing the request body.
+   * @returns The created {@link GameSession} document.
+   */
   @Security("jwt", ["admin"])
   static async POST(req: NextRequest) {
     try {

--- a/apps/backend/src/app/api/admin/game-sessions/route.ts
+++ b/apps/backend/src/app/api/admin/game-sessions/route.ts
@@ -1,0 +1,33 @@
+import { CreateGameSessionRequestSchema } from "@repo/shared"
+import { getReasonPhrase, StatusCodes } from "http-status-codes"
+import { type NextRequest, NextResponse } from "next/server"
+import { ZodError } from "zod"
+import { Security } from "@/business-layer/middleware/Security"
+import GameSessionDataService from "@/data-layer/services/GameSessionDataService"
+
+class GameSessionRouteWrapper {
+  @Security("jwt", ["admin"])
+  static async POST(req: NextRequest) {
+    try {
+      const parsedBody = CreateGameSessionRequestSchema.parse(await req.json())
+      const gameSessionDataService = new GameSessionDataService()
+      const newGameSession = await gameSessionDataService.createGameSession(parsedBody)
+
+      return NextResponse.json({ data: newGameSession }, { status: StatusCodes.CREATED })
+    } catch (error) {
+      if (error instanceof ZodError) {
+        return NextResponse.json(
+          { error: "Invalid request body", details: error.flatten() },
+          { status: StatusCodes.BAD_REQUEST },
+        )
+      }
+      console.error(error)
+      return NextResponse.json(
+        { error: getReasonPhrase(StatusCodes.INTERNAL_SERVER_ERROR) },
+        { status: StatusCodes.INTERNAL_SERVER_ERROR },
+      )
+    }
+  }
+}
+
+export const POST = GameSessionRouteWrapper.POST


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes towards the related issue. Please also  include relevant context. List any dependencies that are required for this change. -->

Adds a POST method at `api/admin/game-sessions` to create a new `GameSession`.

Fixes #696

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [ ] Manual testing (requires screenshots or videos)
- [x] Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added thorough tests that prove my fix is effective and that my feature works
- [x] I've requested a review from another user
