### PR TITLE
feat(semester): add endpoint to get `GameSession`s by semester

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -2,6 +2,9 @@
   "languages": {
     "TypeScript": {
       "format_on_save": "on"
+    },
+    "Markdown": {
+      "format_on_save": "on"
     }
   },
   "language_servers": ["...", "!eslint"],

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -7,7 +7,7 @@
       "format_on_save": "on"
     }
   },
-  "language_servers": ["...", "!eslint"],
+  "language_servers": ["...", "!eslint", "!tailwindcss-language-server"],
   "formatter": {
     "language_server": {
       "name": "biome"

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -2,11 +2,9 @@
   "languages": {
     "TypeScript": {
       "format_on_save": "on"
-    },
-    "Markdown": {
-      "format_on_save": "on"
     }
   },
+  "language_servers": ["...", "!eslint"],
   "formatter": {
     "language_server": {
       "name": "biome"

--- a/apps/backend/src/app/api/semesters/[id]/game-sessions/route.test.ts
+++ b/apps/backend/src/app/api/semesters/[id]/game-sessions/route.test.ts
@@ -1,0 +1,58 @@
+import { getReasonPhrase, StatusCodes } from "http-status-codes"
+import { describe, expect, it, vi } from "vitest"
+import GameSessionDataService from "@/data-layer/services/GameSessionDataService"
+import SemesterDataService from "@/data-layer/services/SemesterDataService"
+import { createMockNextRequest } from "@/test-config/backend-utils"
+import { gameSessionCreateMock } from "@/test-config/mocks/GameSession.mock"
+import { semesterCreateMock } from "@/test-config/mocks/Semester.mock"
+import { GET } from "./route"
+
+describe("/api/semesters/[id]/game-sessions", () => {
+  const semesterDataService = new SemesterDataService()
+  const gameSessionDataService = new GameSessionDataService()
+
+  describe("GET", () => {
+    it("should return game sessions for a valid semester", async () => {
+      const newSemester = await semesterDataService.createSemester(semesterCreateMock)
+      const newSession = await gameSessionDataService.createGameSession({
+        ...gameSessionCreateMock,
+        semester: newSemester,
+      })
+
+      const res = await GET(createMockNextRequest(), {
+        params: Promise.resolve({ id: newSemester.id }),
+      })
+
+      expect(res.status).toBe(StatusCodes.OK)
+      const data = await res.json()
+      expect(data.data).toEqual([newSession])
+    })
+
+    it("should return 404 when semester does not exist", async () => {
+      const res = await GET(createMockNextRequest(), {
+        params: Promise.resolve({ id: "non-existent" }),
+      })
+
+      expect(res.status).toBe(StatusCodes.NOT_FOUND)
+      const data = await res.json()
+      expect(data.error).toBe("Semester not found")
+    })
+
+    it("should handle errors and return 500 status", async () => {
+      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+      vi.spyOn(SemesterDataService.prototype, "getSemesterById").mockRejectedValueOnce(
+        new Error("Database error"),
+      )
+
+      const res = await GET(createMockNextRequest(), {
+        params: Promise.resolve({ id: "any-id" }),
+      })
+
+      expect(res.status).toBe(StatusCodes.INTERNAL_SERVER_ERROR)
+      const data = await res.json()
+      expect(data.error).toBe(getReasonPhrase(StatusCodes.INTERNAL_SERVER_ERROR))
+      expect(consoleErrorSpy).toHaveBeenCalled()
+      consoleErrorSpy.mockRestore()
+    })
+  })
+})

--- a/apps/backend/src/app/api/semesters/[id]/game-sessions/route.ts
+++ b/apps/backend/src/app/api/semesters/[id]/game-sessions/route.ts
@@ -1,18 +1,26 @@
+import { GameSessionTimeframe } from "@repo/shared"
 import { getReasonPhrase, StatusCodes } from "http-status-codes"
 import { type NextRequest, NextResponse } from "next/server"
 import { NotFound } from "payload"
 import GameSessionDataService from "@/data-layer/services/GameSessionDataService"
 import SemesterDataService from "@/data-layer/services/SemesterDataService"
 
-export const GET = async (_req: NextRequest, { params }: { params: Promise<{ id: string }> }) => {
+export const GET = async (req: NextRequest, { params }: { params: Promise<{ id: string }> }) => {
   const { id } = await params
+  const searchParams = req.nextUrl.searchParams
+  const timeframe = (searchParams.get("timeframe") ||
+    GameSessionTimeframe.DEFAULT) as GameSessionTimeframe
 
   try {
     const semesterDataService = new SemesterDataService()
     const gameSessionDataService = new GameSessionDataService()
 
     const semester = await semesterDataService.getSemesterById(id)
-    const sessions = await gameSessionDataService.getGameSessionsBySemesterId(semester.id)
+    const sessions = await gameSessionDataService.getGameSessionsBySemesterId(
+      semester.id,
+      timeframe,
+    )
+
     return NextResponse.json({ data: sessions })
   } catch (error) {
     if (error instanceof NotFound) {

--- a/apps/backend/src/app/api/semesters/[id]/game-sessions/route.ts
+++ b/apps/backend/src/app/api/semesters/[id]/game-sessions/route.ts
@@ -1,0 +1,27 @@
+import { getReasonPhrase, StatusCodes } from "http-status-codes"
+import { type NextRequest, NextResponse } from "next/server"
+import { NotFound } from "payload"
+import GameSessionDataService from "@/data-layer/services/GameSessionDataService"
+import SemesterDataService from "@/data-layer/services/SemesterDataService"
+
+export const GET = async (_req: NextRequest, { params }: { params: Promise<{ id: string }> }) => {
+  const { id } = await params
+
+  try {
+    const semesterDataService = new SemesterDataService()
+    const gameSessionDataService = new GameSessionDataService()
+
+    const semester = await semesterDataService.getSemesterById(id)
+    const sessions = await gameSessionDataService.getGameSessionsBySemesterId(semester.id)
+    return NextResponse.json({ data: sessions })
+  } catch (error) {
+    if (error instanceof NotFound) {
+      return NextResponse.json({ error: "Semester not found" }, { status: StatusCodes.NOT_FOUND })
+    }
+    console.error(error)
+    return NextResponse.json(
+      { error: getReasonPhrase(StatusCodes.INTERNAL_SERVER_ERROR) },
+      { status: StatusCodes.INTERNAL_SERVER_ERROR },
+    )
+  }
+}

--- a/apps/backend/src/app/api/semesters/[id]/game-sessions/route.ts
+++ b/apps/backend/src/app/api/semesters/[id]/game-sessions/route.ts
@@ -1,4 +1,4 @@
-import { GameSessionTimeframe } from "@repo/shared"
+import { GameSessionTimeframe, SearchParams } from "@repo/shared"
 import { getReasonPhrase, StatusCodes } from "http-status-codes"
 import { type NextRequest, NextResponse } from "next/server"
 import { NotFound } from "payload"
@@ -8,7 +8,7 @@ import SemesterDataService from "@/data-layer/services/SemesterDataService"
 export const GET = async (req: NextRequest, { params }: { params: Promise<{ id: string }> }) => {
   const { id } = await params
   const searchParams = req.nextUrl.searchParams
-  const timeframe = (searchParams.get("timeframe") ||
+  const timeframe = (searchParams.get(SearchParams.SESSION_TIMEFRAME) ||
     GameSessionTimeframe.DEFAULT) as GameSessionTimeframe
 
   try {

--- a/apps/backend/src/data-layer/services/GameSessionDataService.test.ts
+++ b/apps/backend/src/data-layer/services/GameSessionDataService.test.ts
@@ -284,7 +284,7 @@ describe("GameSessionDataService", () => {
         ...gameSessionCreateMock,
         semester: id,
         endTime: new Date(now.getTime() + 1000 * 60 * 60 * 24).toISOString(), // 1 day from now
-        openTime: new Date(now.getTime() + 1000 * 60 * 60).toISOString(), // 1 hour ago
+        openTime: new Date(now.getTime() + 1000 * 60 * 60).toISOString(), // 1 hour later
       })
 
       // Should only return the current session

--- a/apps/backend/src/data-layer/services/GameSessionDataService.test.ts
+++ b/apps/backend/src/data-layer/services/GameSessionDataService.test.ts
@@ -238,16 +238,16 @@ describe("GameSessionDataService", () => {
       await gameSessionDataService.createGameSession({
         ...gameSessionCreateMock,
         semester: id,
-        startTime: new Date(now.getTime() - 1000 * 60 * 60).toISOString(), // 1 hour ago
+        startTime: new Date(now.getTime() + 1000 * 60 * 60).toISOString(), // 1 hour from now
         endTime: new Date(now.getTime() + 1000 * 60 * 60).toISOString(), // 1 hour from now
       })
 
-      // PAST: startTime > now
+      // PAST: startTime < now
       const pastSession = await gameSessionDataService.createGameSession({
         ...gameSessionCreateMock,
         semester: id,
-        startTime: new Date(now.getTime() + 1000 * 60 * 60 * 24).toISOString(), // 1 day from now
-        endTime: new Date(now.getTime() + 1000 * 60 * 60 * 25).toISOString(), // 25 hours from now
+        startTime: new Date(now.getTime() - 1000 * 60 * 60 * 24).toISOString(), // 1 day before now
+        endTime: new Date(now.getTime() - 1000 * 60 * 60 * 25).toISOString(), // 25 hours before now
       })
 
       // Should only return the past session
@@ -263,15 +263,15 @@ describe("GameSessionDataService", () => {
       const { id } = await semesterDataService.createSemester(semesterCreateMock)
       const now = new Date()
 
-      // CURRENT: endDate >= now && openTime >= now
+      // CURRENT: endDate >= now && openTime <= now
       const currentSession = await gameSessionDataService.createGameSession({
         ...gameSessionCreateMock,
         semester: id,
+        openTime: new Date(now.getTime() - 1000 * 60 * 60).toISOString(), // 1 hour before now
         endTime: new Date(now.getTime() + 1000 * 60 * 60 * 24).toISOString(), // 1 day from now
-        openTime: new Date(now.getTime() + 1000 * 60 * 60).toISOString(), // 1 hour from now
       })
 
-      // Not CURRENT: endDate < now
+      // Not CURRENT(PAST): endDate < now
       await gameSessionDataService.createGameSession({
         ...gameSessionCreateMock,
         semester: id,
@@ -279,12 +279,12 @@ describe("GameSessionDataService", () => {
         openTime: new Date(now.getTime() + 1000 * 60 * 60).toISOString(), // 1 hour from now
       })
 
-      // Not CURRENT: openTime < now
+      // Not CURRENT: openTime > now
       await gameSessionDataService.createGameSession({
         ...gameSessionCreateMock,
         semester: id,
         endTime: new Date(now.getTime() + 1000 * 60 * 60 * 24).toISOString(), // 1 day from now
-        openTime: new Date(now.getTime() - 1000 * 60 * 60).toISOString(), // 1 hour ago
+        openTime: new Date(now.getTime() + 1000 * 60 * 60).toISOString(), // 1 hour ago
       })
 
       // Should only return the current session

--- a/apps/backend/src/data-layer/services/GameSessionDataService.ts
+++ b/apps/backend/src/data-layer/services/GameSessionDataService.ts
@@ -115,7 +115,7 @@ export default class GameSessionDataService {
       case GameSessionTimeframe.PAST:
         filter = {
           startTime: {
-            greater_than: currentDate,
+            less_than: currentDate,
           },
         }
         break
@@ -129,7 +129,7 @@ export default class GameSessionDataService {
             },
             {
               openTime: {
-                greater_than_equal: currentDate,
+                less_than_equal: currentDate,
               },
             },
           ],

--- a/apps/backend/src/data-layer/services/GameSessionDataService.ts
+++ b/apps/backend/src/data-layer/services/GameSessionDataService.ts
@@ -95,7 +95,7 @@ export default class GameSessionDataService {
     semesterId: string,
     timeframe: GameSessionTimeframe = GameSessionTimeframe.DEFAULT,
   ): Promise<GameSession[]> {
-    const currentDate = new Date().toISOString()
+    const currentDate = new Date()
 
     let filter: Where = {}
     const sort: Sort = "-startTime"

--- a/apps/backend/src/data-layer/services/GameSessionDataService.ts
+++ b/apps/backend/src/data-layer/services/GameSessionDataService.ts
@@ -82,6 +82,26 @@ export default class GameSessionDataService {
   }
 
   /**
+   * Gets all {@link GameSession} documents for a given semester ID
+   *
+   * @param semesterId the ID of the {@link Semester} to get game sessions for
+   * @returns an array of {@link GameSession} documents
+   */
+  public async getGameSessionsBySemesterId(semesterId: string): Promise<GameSession[]> {
+    return (
+      await payload.find({
+        collection: "gameSession",
+        where: {
+          semester: {
+            equals: semesterId,
+          },
+        },
+        pagination: false,
+      })
+    ).docs
+  }
+
+  /**
    * Creates a new {@link GameSessionSchedule} document
    *
    * @param {CreateGameSessionScheduleData} newGameSessionScheduleData the game session schedule data

--- a/apps/backend/src/data-layer/services/GameSessionDataService.ts
+++ b/apps/backend/src/data-layer/services/GameSessionDataService.ts
@@ -103,13 +103,9 @@ export default class GameSessionDataService {
     switch (timeframe) {
       case GameSessionTimeframe.UPCOMING:
         filter = {
-          and: [
-            {
-              startTime: {
-                greater_than_equal: currentDate,
-              },
-            },
-          ],
+          startTime: {
+            greater_than_equal: currentDate,
+          },
         }
         break
       case GameSessionTimeframe.PAST:

--- a/apps/backend/src/data-layer/services/GameSessionDataService.ts
+++ b/apps/backend/src/data-layer/services/GameSessionDataService.ts
@@ -119,7 +119,21 @@ export default class GameSessionDataService {
           },
         }
         break
-      case GameSessionTimeframe.NEXT:
+      case GameSessionTimeframe.CURRENT:
+        filter = {
+          and: [
+            {
+              endTime: {
+                greater_than_equal: currentDate,
+              },
+            },
+            {
+              openTime: {
+                greater_than_equal: currentDate,
+              },
+            },
+          ],
+        }
         break
       default:
     }

--- a/packages/shared/src/enums/game-session.ts
+++ b/packages/shared/src/enums/game-session.ts
@@ -8,9 +8,9 @@ export enum GameSessionTimeframe {
    */
   PAST = "past",
   /**
-   * Any game sessions that are upcoming (excludes past game sessions, or game sessions too far in the future)
+   * Any game sessions that are current (excludes past game sessions, or game sessions too far in the future)
    */
-  NEXT = "next",
+  CURRENT = "current",
   /**
    * All of the game sessions
    */

--- a/packages/shared/src/enums/game-session.ts
+++ b/packages/shared/src/enums/game-session.ts
@@ -1,0 +1,18 @@
+export enum GameSessionTimeframe {
+  /**
+   * Any game sessions that are upcoming (excludes past game sessions)
+   */
+  UPCOMING = "upcoming",
+  /**
+   * Any game sessions that are past (excludes upcoming game sessions)
+   */
+  PAST = "past",
+  /**
+   * Any game sessions that are upcoming (excludes past game sessions, or game sessions too far in the future)
+   */
+  NEXT = "next",
+  /**
+   * All of the game sessions
+   */
+  DEFAULT = "default",
+}

--- a/packages/shared/src/enums/game-session.ts
+++ b/packages/shared/src/enums/game-session.ts
@@ -8,7 +8,7 @@ export enum GameSessionTimeframe {
    */
   PAST = "past",
   /**
-   * Any game sessions that are current (excludes past game sessions, or game sessions too far in the future)
+   * Any game sessions that are current (excludes past game sessions, or sessions that aren't open yet)
    */
   CURRENT = "current",
   /**

--- a/packages/shared/src/enums/index.ts
+++ b/packages/shared/src/enums/index.ts
@@ -1,3 +1,4 @@
 export * from "./game-session"
 export * from "./popup"
 export * from "./routes"
+export * from "./search-params"

--- a/packages/shared/src/enums/index.ts
+++ b/packages/shared/src/enums/index.ts
@@ -1,2 +1,3 @@
+export * from "./game-session"
 export * from "./popup"
 export * from "./routes"

--- a/packages/shared/src/enums/search-params.ts
+++ b/packages/shared/src/enums/search-params.ts
@@ -1,0 +1,6 @@
+export enum SearchParams {
+  /**
+   * The game session timeframe search param
+   */
+  SESSION_TIMEFRAME = "sessionTimeframe",
+}


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes towards the related issue. Please also  include relevant context. List any dependencies that are required for this change. -->

We didn't really have an option to get game sessions by semester. This PR introduces that endpoint so that we can fetch all game session documents based on a semester. 

There are 4 different filter options:

1. Upcoming - Any game sessions that are upcoming (excludes past game sessions)
2. Past - Any game sessions that are past (excludes upcoming game sessions)
3. Current - Any game sessions that are current (excludes past game sessions, or game sessions too far in the future)
4. Default - All of the game sessions

Fixes #724 

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added thorough tests that prove my fix is effective and that my feature works
- [x] I've requested a review from another user
