### PR TITLE
refactor(game-session): add open time to `GameSession`

### DIFF
--- a/apps/backend/src/app/api/admin/game-sessions/route.test.ts
+++ b/apps/backend/src/app/api/admin/game-sessions/route.test.ts
@@ -1,14 +1,17 @@
-import { AUTH_COOKIE_NAME } from "@repo/shared"
+import { AUTH_COOKIE_NAME, Weekday } from "@repo/shared"
 import { StatusCodes } from "http-status-codes"
 import { cookies } from "next/headers"
 import GameSessionDataService from "@/data-layer/services/GameSessionDataService"
+import SemesterDataService from "@/data-layer/services/SemesterDataService"
 import { createMockNextRequest } from "@/test-config/backend-utils"
 import { gameSessionCreateMock } from "@/test-config/mocks/GameSession.mock"
+import { semesterCreateMock } from "@/test-config/mocks/Semester.mock"
 import { adminToken, casualToken, memberToken } from "@/test-config/vitest.setup"
 import { POST } from "./route"
 
 describe("api/admin/game-sessions", async () => {
   const gameSessionDataService = new GameSessionDataService()
+  const semesterDataService = new SemesterDataService()
   const cookieStore = await cookies()
 
   describe("POST", () => {
@@ -32,13 +35,25 @@ describe("api/admin/game-sessions", async () => {
 
     it("should allow admins to create a game session", async () => {
       cookieStore.set(AUTH_COOKIE_NAME, adminToken)
+      const semester = await semesterDataService.createSemester(semesterCreateMock)
 
-      const res = await POST(createMockNextRequest("", "POST", gameSessionCreateMock))
+      const res = await POST(
+        createMockNextRequest("", "POST", { ...gameSessionCreateMock, semester }),
+      )
 
       expect(res.status).toBe(StatusCodes.CREATED)
       const data = (await res.json()).data
       const fetchedGameSession = await gameSessionDataService.getGameSessionById(data.id)
       expect(data).toEqual(fetchedGameSession)
+      // Ensure that the openTime field is also correct
+      const openDate = new Date(fetchedGameSession.openTime)
+      const semesterBookingOpenDay = Object.values(Weekday).indexOf(
+        semester.bookingOpenDay as Weekday,
+      )
+      const semesterBookingOpenTime = new Date(semester.bookingOpenTime)
+      expect(openDate.getUTCDay() === semesterBookingOpenDay).toBe(true)
+      expect(openDate.getUTCHours() === semesterBookingOpenTime.getUTCHours()).toBe(true)
+      expect(openDate.getUTCMinutes() === semesterBookingOpenTime.getUTCMinutes()).toBe(true)
     })
 
     it("should return a 400 status when request body is invalid", async () => {

--- a/apps/backend/src/app/api/admin/game-sessions/route.ts
+++ b/apps/backend/src/app/api/admin/game-sessions/route.ts
@@ -1,10 +1,11 @@
-import { CreateGameSessionRequestSchema } from "@repo/shared"
+import { CreateGameSessionRequestSchema, getGameSessionOpenDay } from "@repo/shared"
 import { getReasonPhrase, StatusCodes } from "http-status-codes"
 import { type NextRequest, NextResponse } from "next/server"
 import { ZodError } from "zod"
 import { Security } from "@/business-layer/middleware/Security"
 import type { GameSession } from "@/data-layer/collections/GameSession"
 import GameSessionDataService from "@/data-layer/services/GameSessionDataService"
+import SemesterDataService from "@/data-layer/services/SemesterDataService"
 
 class GameSessionRouteWrapper {
   /**
@@ -15,10 +16,20 @@ class GameSessionRouteWrapper {
    */
   @Security("jwt", ["admin"])
   static async POST(req: NextRequest) {
+    const gameSessionDataService = new GameSessionDataService()
+    const semesterDataService = new SemesterDataService()
+
     try {
       const parsedBody = CreateGameSessionRequestSchema.parse(await req.json())
-      const gameSessionDataService = new GameSessionDataService()
-      const newGameSession = await gameSessionDataService.createGameSession(parsedBody)
+      const semester =
+        typeof parsedBody.semester === "string"
+          ? await semesterDataService.getSemesterById(parsedBody.semester)
+          : parsedBody.semester
+
+      const newGameSession = await gameSessionDataService.createGameSession({
+        ...parsedBody,
+        openTime: getGameSessionOpenDay(semester, new Date(parsedBody.startTime)).toISOString(),
+      })
 
       return NextResponse.json({ data: newGameSession }, { status: StatusCodes.CREATED })
     } catch (error) {

--- a/apps/backend/src/data-layer/collections/GameSession.ts
+++ b/apps/backend/src/data-layer/collections/GameSession.ts
@@ -43,6 +43,17 @@ export const GameSession: CollectionConfig = {
       },
     },
     {
+      name: "openTime",
+      type: "date",
+      required: true,
+      admin: {
+        date: {
+          pickerAppearance: "dayAndTime",
+        },
+        description: "The open time of the game session",
+      },
+    },
+    {
       name: "startTime",
       type: "date",
       required: true,

--- a/apps/backend/src/data-layer/services/GameSessionDataService.test.ts
+++ b/apps/backend/src/data-layer/services/GameSessionDataService.test.ts
@@ -7,9 +7,10 @@ import { getWeeklySessionDates } from "../utils/DateUtils"
 import GameSessionDataService from "./GameSessionDataService"
 import SemesterDataService from "./SemesterDataService"
 
-const gameSessionDataService = new GameSessionDataService()
-
 describe("GameSessionDataService", () => {
+  const gameSessionDataService = new GameSessionDataService()
+  const semesterDataService = new SemesterDataService()
+
   describe("createGameSession", () => {
     it("should create a game session document", async () => {
       const newGameSession = await gameSessionDataService.createGameSession(gameSessionCreateMock)
@@ -22,7 +23,6 @@ describe("GameSessionDataService", () => {
   })
 
   describe("cascadeCreateGameSessions", () => {
-    const semesterDataService = new SemesterDataService()
     it("should create multiple game session documents excluding mid-semester break", async () => {
       const newSemester = await semesterDataService.createSemester({
         ...semesterCreateMock,
@@ -50,6 +50,16 @@ describe("GameSessionDataService", () => {
         const breakStart = new Date(newSemester.breakStart)
         const breakEnd = new Date(newSemester.breakEnd)
         expect(sessionDate < breakStart || sessionDate > breakEnd).toBe(true)
+
+        const openDate = new Date(session.openTime)
+        const semesterBookingOpenDay = Object.values(Weekday).indexOf(
+          newSemester.bookingOpenDay as Weekday,
+        )
+        const semesterBookingOpenTime = new Date(newSemester.bookingOpenTime)
+        expect(openDate <= sessionDate).toBe(true)
+        expect(openDate.getUTCDay() === semesterBookingOpenDay).toBe(true)
+        expect(openDate.getUTCHours() === semesterBookingOpenTime.getUTCHours()).toBe(true)
+        expect(openDate.getUTCMinutes() === semesterBookingOpenTime.getUTCMinutes()).toBe(true)
       }
     })
   })

--- a/apps/backend/src/data-layer/services/GameSessionDataService.ts
+++ b/apps/backend/src/data-layer/services/GameSessionDataService.ts
@@ -125,7 +125,7 @@ export default class GameSessionDataService {
         openTime: getGameSessionOpenDay(
           semester,
           new Date(gameSessionTimes.startTime),
-        ).toUTCString(),
+        ).toISOString(),
       }
     })
 

--- a/apps/backend/src/data-layer/services/GameSessionDataService.ts
+++ b/apps/backend/src/data-layer/services/GameSessionDataService.ts
@@ -1,9 +1,10 @@
-import type {
-  CreateGameSessionData,
-  CreateGameSessionScheduleData,
-  UpdateGameSessionData,
-  UpdateGameSessionScheduleData,
-  Weekday,
+import {
+  type CreateGameSessionData,
+  type CreateGameSessionScheduleData,
+  getGameSessionOpenDay,
+  type UpdateGameSessionData,
+  type UpdateGameSessionScheduleData,
+  type Weekday,
 } from "@repo/shared"
 import type { GameSession, GameSessionSchedule, Semester } from "@repo/shared/payload-types"
 import type { PaginatedDocs } from "payload"
@@ -121,6 +122,10 @@ export default class GameSessionDataService {
         ...gameSessionTimes,
         capacity: schedule.capacity,
         casualCapacity: schedule.casualCapacity,
+        openTime: getGameSessionOpenDay(
+          semester,
+          new Date(gameSessionTimes.startTime),
+        ).toUTCString(),
       }
     })
 

--- a/apps/backend/src/data-layer/utils/DateUtils.ts
+++ b/apps/backend/src/data-layer/utils/DateUtils.ts
@@ -17,14 +17,14 @@ export function getWeeklySessionDates(day: Weekday, semester: Semester): Date[] 
   const breakEnd = new Date(semester.breakEnd)
 
   const sessionDate = new Date(semesterStart)
-  const dayOffSet = getDaysBetweenWeekdays(Object.values(Weekday)[sessionDate.getDay()], day)
-  sessionDate.setDate(sessionDate.getDate() + dayOffSet)
+  const dayOffSet = getDaysBetweenWeekdays(Object.values(Weekday)[sessionDate.getUTCDay()], day)
+  sessionDate.setDate(sessionDate.getUTCDate() + dayOffSet)
 
   while (sessionDate <= semesterEnd) {
     if (sessionDate < breakStart || sessionDate > breakEnd) {
       dates.push(new Date(sessionDate))
     }
-    sessionDate.setDate(sessionDate.getDate() + 7)
+    sessionDate.setDate(sessionDate.getUTCDate() + 7)
   }
 
   return dates

--- a/apps/backend/src/test-config/mocks/GameSession.mock.ts
+++ b/apps/backend/src/test-config/mocks/GameSession.mock.ts
@@ -6,6 +6,7 @@ export const gameSessionCreateMock: CreateGameSessionData = {
   semester: semesterMock,
   startTime: new Date().toISOString(),
   endTime: new Date().toISOString(),
+  openTime: new Date().toISOString(),
   capacity: 10,
   casualCapacity: 8,
 }
@@ -14,6 +15,7 @@ export const oneOffGameSessionCreateMock: CreateGameSessionData = {
   semester: semesterMock,
   startTime: new Date().toISOString(),
   endTime: new Date().toISOString(),
+  openTime: new Date().toISOString(),
   capacity: 10,
   casualCapacity: 8,
   location: "240 Straight Zhao St",
@@ -25,6 +27,7 @@ export const gameSessionMock: GameSession = {
   semester: semesterMock,
   startTime: new Date().toISOString(),
   endTime: new Date().toISOString(),
+  openTime: new Date().toISOString(),
   capacity: 10,
   casualCapacity: 8,
   updatedAt: new Date(2025, 0, 1).toISOString(),

--- a/packages/shared/src/mocks/GameSession.mock.ts
+++ b/packages/shared/src/mocks/GameSession.mock.ts
@@ -7,6 +7,7 @@ export const gameSessionMock: GameSession = {
   semester: semesterMock,
   startTime: new Date(Date.UTC(2025, 6, 19, 9, 0, 0)).toISOString(),
   endTime: new Date(Date.UTC(2025, 6, 19, 11, 0, 0)).toISOString(),
+  openTime: new Date(Date.UTC(2025, 6, 19, 8, 0, 0)).toISOString(),
   gameSessionSchedule: gameSessionScheduleMock,
   capacity: 10,
   casualCapacity: 8,
@@ -19,4 +20,5 @@ export const gameSessionMockBookingNotOpen: GameSession = {
   semester: semesterMockBookingNotOpen,
   startTime: new Date(Date.UTC(2025, 6, 21, 9, 0, 0)).toISOString(), // Monday July 21, 2025 at 9am UTC
   endTime: new Date(Date.UTC(2025, 6, 21, 11, 0, 0)).toISOString(), // Monday July 21, 2025 at 11am UTC
+  openTime: new Date(Date.UTC(2025, 6, 21, 8, 0, 0)).toISOString(),
 }

--- a/packages/shared/src/payload-types.ts
+++ b/packages/shared/src/payload-types.ts
@@ -463,6 +463,10 @@ export interface GameSession {
    */
   location?: string | null;
   /**
+   * The open time of the game session
+   */
+  openTime: string;
+  /**
    * The start time of the game session
    */
   startTime: string;
@@ -760,6 +764,7 @@ export interface GameSessionSelect<T extends boolean = true> {
   semester?: T;
   name?: T;
   location?: T;
+  openTime?: T;
   startTime?: T;
   endTime?: T;
   capacity?: T;

--- a/packages/shared/src/schemas/game-session.ts
+++ b/packages/shared/src/schemas/game-session.ts
@@ -9,6 +9,7 @@ export const GameSessionSchema = z.object({
   id: z.string(),
   gameSessionSchedule: z.union([z.string(), GameSessionScheduleSchema]).nullable().optional(),
   semester: z.union([z.string(), SemesterSchema]),
+  openTime: z.string().datetime({ message: "Invalid date format, should be in ISO 8601 format" }),
   startTime: z.string().datetime({ message: "Invalid date format, should be in ISO 8601 format" }),
   endTime: z.string().datetime({ message: "Invalid date format, should be in ISO 8601 format" }),
   name: z.string().nullable().optional(),

--- a/packages/shared/src/schemas/game-session.ts
+++ b/packages/shared/src/schemas/game-session.ts
@@ -24,7 +24,8 @@ export const CreateGameSessionRequestSchema = GameSessionSchema.omit({
   updatedAt: true,
   createdAt: true,
   id: true,
-}) satisfies z.ZodType<CreateGameSessionData>
+  openTime: true,
+}) satisfies z.ZodType<Omit<CreateGameSessionData, "openTime">>
 
 export const UpdateGameSessionRequestSchema =
   CreateGameSessionRequestSchema.partial() satisfies z.ZodType<UpdateGameSessionData>

--- a/packages/shared/src/utils/date.ts
+++ b/packages/shared/src/utils/date.ts
@@ -1,5 +1,5 @@
 import { format } from "date-fns"
-import type { Semester } from "src/payload-types"
+import type { Semester } from "../payload-types"
 import { Weekday } from "../types"
 
 /**

--- a/packages/shared/src/utils/date.ts
+++ b/packages/shared/src/utils/date.ts
@@ -1,4 +1,5 @@
 import { format } from "date-fns"
+import type { Semester } from "src/payload-types"
 import { Weekday } from "../types"
 
 /**
@@ -48,4 +49,32 @@ export function calculateOpenDate(startTime: Date, openDay: Weekday, openTime: D
  */
 export function formatDateWithOrdinal(date: string | Date): string {
   return format(new Date(date), "eeee, do 'of' MMMM")
+}
+
+/**
+ * Calculates the open date for a session based on the start time, open day, and open time.
+ *
+ * @param semester The {@link Semester} object containing booking open day and time
+ * @param startTime The start time
+ * @returns The calculated booking open date
+ */
+export function getGameSessionOpenDay(semester: Semester, startTime: Date): Date {
+  const { bookingOpenDay, bookingOpenTime } = semester
+
+  const openDate = new Date(startTime)
+  const openTime = new Date(bookingOpenTime)
+
+  const dayIndex = startTime.getUTCDay()
+  const day = Object.values(Weekday)[dayIndex] as Weekday
+  const daysToSubtract = getDaysBetweenWeekdays(bookingOpenDay as Weekday, day)
+
+  openDate.setUTCDate(startTime.getUTCDate() - daysToSubtract)
+  openDate.setUTCHours(
+    openTime.getUTCHours(),
+    openTime.getUTCMinutes(),
+    openTime.getUTCSeconds(),
+    0,
+  )
+
+  return openDate
 }


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes towards the related issue. Please also  include relevant context. List any dependencies that are required for this change. -->

There wasn't an `openTime` field in `GameSession` documents previously, this made it a lot more difficult to query within the `data-layer`. This also makes it easier in the frontend to check if any sessions are not open yet. 

All `POST` and `GameSession` related backend routes have been modified to omit `openTime` and to create that field with internal logic. A date util function has been added and tested to get the `openTime` based on a semesters specified open day/time and the actual start time of the `GameSession`.

Fixes #727 

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

<img width="994" height="437" alt="image" src="https://github.com/user-attachments/assets/85afa918-5ee6-4def-83e7-78f102b1b556" />

- [x] This requires a documentation update 

# How Has This Been Tested?

- [x] Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added thorough tests that prove my fix is effective and that my feature works
- [x] I've requested a review from another user
