### PR TITLE
[WIP] feat(frontend): add logout page

### DIFF
--- a/apps/frontend/src/app/auth/logout/page.tsx
+++ b/apps/frontend/src/app/auth/logout/page.tsx
@@ -1,0 +1,19 @@
+"use client"
+
+import { Center, Loading } from "@yamada-ui/react"
+import { Suspense } from "react"
+import { LogoutSection } from "@/components/client/auth/LogoutSection"
+
+export default function CallbackPage() {
+  return (
+    <Suspense
+      fallback={
+        <Center layerStyle="container">
+          <Loading fontSize="5xl" />
+        </Center>
+      }
+    >
+      <LogoutSection />
+    </Suspense>
+  )
+}

--- a/apps/frontend/src/components/client/auth/LogoutSection.tsx
+++ b/apps/frontend/src/components/client/auth/LogoutSection.tsx
@@ -1,0 +1,25 @@
+import { Center, Loading, Text, VStack } from "@yamada-ui/react"
+import { useRouter } from "next/navigation"
+import { useEffect, useRef } from "react"
+import { useAuth } from "@/context/AuthContext"
+
+export const LogoutSection = () => {
+  const router = useRouter()
+  const { logout, isLoading, isPending } = useAuth()
+  const loggedOut = useRef(false)
+
+  useEffect(() => {
+    if (!isLoading && !isPending && !loggedOut.current) {
+      loggedOut.current = true
+      logout()
+      router.push("/")
+    }
+  }, [logout, router, isLoading, isPending])
+
+  return (
+    <Center as={VStack} gap="lg" layerStyle="container">
+      <Loading fontSize="5xl" />
+      <Text>Logging you out...</Text>
+    </Center>
+  )
+}

--- a/apps/frontend/src/context/AuthContext.tsx
+++ b/apps/frontend/src/context/AuthContext.tsx
@@ -56,6 +56,7 @@ type AuthActions = {
     unknown
   >
   setToken: (token: string | null) => void
+  logout: () => void
 }
 
 export type AuthContextValue = AuthState & AuthActions
@@ -138,6 +139,15 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     },
   })
 
+  const logout = () => {
+    setToken(null)
+    notice({
+      title: "Logged out",
+      description: "You have been logged out successfully.",
+      status: "success",
+    })
+  }
+
   const authState: AuthState = {
     user: user ?? null,
     isLoading: isLoading || login.isPending,
@@ -152,6 +162,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     emailVerificationCode,
     register,
     setToken,
+    logout,
   }
 
   useUpdateEffect(() => {

--- a/packages/theme/src/config.ts
+++ b/packages/theme/src/config.ts
@@ -1,5 +1,10 @@
-import type { BreakpointOptions } from "@yamada-ui/core"
+import type { BreakpointOptions, NoticeConfigOptions } from "@yamada-ui/core"
 
 export const breakpoint: BreakpointOptions = { direction: "up" }
 
 export const initialColorMode = "dark"
+
+export const noticeOptions: NoticeConfigOptions = {
+  isClosable: true,
+  closeStrategy: "both",
+}

--- a/packages/theme/src/index.ts
+++ b/packages/theme/src/index.ts
@@ -1,12 +1,16 @@
 import type { ThemeConfig, UsageTheme } from "@yamada-ui/core"
 import { extendConfig, extendTheme } from "@yamada-ui/theme-tools"
 import { components } from "./components"
-import { breakpoint, initialColorMode } from "./config"
+import { breakpoint, initialColorMode, noticeOptions } from "./config"
 import { semantics } from "./semantics"
 import { styles } from "./styles"
 import { tokens } from "./tokens"
 
-export const defaultConfig: ThemeConfig = { breakpoint, initialColorMode }
+export const defaultConfig: ThemeConfig = {
+  breakpoint,
+  initialColorMode,
+  notice: { options: noticeOptions },
+}
 
 export const config = extendConfig(defaultConfig)
 


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes towards the related issue. Please also include relevant context. List any dependencies that are required for this change. -->

Adds a logout page linked to the navbar that removes the current token from the auth context.
Adds the ability to close notifications by default, as notifications cover the navbar and currently stop users from being able to interact with it, and they must sit there waiting.

Fixes #717 

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)
- [ ] Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added thorough tests that prove my fix is effective and that my feature works
- [x] I've requested a review from another user
