### PR TITLE
feat(game-session): adds capacity status to sessions

### DIFF
--- a/apps/backend/src/app/api/semesters/[id]/game-sessions/route.test.ts
+++ b/apps/backend/src/app/api/semesters/[id]/game-sessions/route.test.ts
@@ -1,3 +1,4 @@
+import { CapacityStatus } from "@repo/shared"
 import { getReasonPhrase, StatusCodes } from "http-status-codes"
 import { describe, expect, it, vi } from "vitest"
 import GameSessionDataService from "@/data-layer/services/GameSessionDataService"
@@ -25,7 +26,15 @@ describe("/api/semesters/[id]/game-sessions", () => {
 
       expect(res.status).toBe(StatusCodes.OK)
       const data = await res.json()
-      expect(data.data).toEqual([newSession])
+      expect(data.data).toEqual([
+        {
+          ...newSession,
+          regularBookings: 0,
+          casualBookings: 0,
+          regularCapacityStatus: CapacityStatus.available,
+          casualCapacityStatus: CapacityStatus.available,
+        },
+      ])
     })
 
     it("should return 404 when semester does not exist", async () => {

--- a/apps/backend/src/app/api/semesters/[id]/game-sessions/route.ts
+++ b/apps/backend/src/app/api/semesters/[id]/game-sessions/route.ts
@@ -1,7 +1,9 @@
-import { SearchParams, TimeframeFilter } from "@repo/shared"
+import { MembershipType, SearchParams, TimeframeFilter } from "@repo/shared"
+import type { User } from "@repo/shared/payload-types"
 import { getReasonPhrase, StatusCodes } from "http-status-codes"
 import { type NextRequest, NextResponse } from "next/server"
 import { NotFound } from "payload"
+import BookingDataService from "@/data-layer/services/BookingDataService"
 import GameSessionDataService from "@/data-layer/services/GameSessionDataService"
 import SemesterDataService from "@/data-layer/services/SemesterDataService"
 
@@ -11,14 +13,31 @@ export const GET = async (req: NextRequest, { params }: { params: Promise<{ id: 
   const timeframe = (searchParams.get(SearchParams.SESSION_TIMEFRAME) ||
     TimeframeFilter.DEFAULT) as TimeframeFilter
 
-  try {
-    const semesterDataService = new SemesterDataService()
-    const gameSessionDataService = new GameSessionDataService()
+  const semesterDataService = new SemesterDataService()
+  const gameSessionDataService = new GameSessionDataService()
+  const bookingDataService = new BookingDataService()
 
+  try {
     const semester = await semesterDataService.getSemesterById(id)
     const sessions = await gameSessionDataService.getGameSessionsBySemesterId(
       semester.id,
       timeframe,
+    )
+
+    await Promise.all(
+      sessions.map(async (session) => {
+        const sessionBookings = await bookingDataService.getAllBookingsBySessionId(id)
+
+        const casualBookings = sessionBookings.filter(
+          (booking) => (booking.user as User)?.role === MembershipType.casual,
+        ).length
+
+        return {
+          ...session,
+          casualCapacityStatus: casualBookings,
+          memberCapacityStatus: sessionBookings.length - casualBookings,
+        }
+      }),
     )
 
     return NextResponse.json({ data: sessions })

--- a/packages/shared/src/schemas/game-session.ts
+++ b/packages/shared/src/schemas/game-session.ts
@@ -43,3 +43,12 @@ export const GetPaginatedGameSessionsResponseSchema = z.object({
 export const GetAllGameSessionsBySemesterResponseSchema = z.object({
   data: z.array(GameSessionSchema),
 })
+
+export const GameSessionWithCapacityStatusSchema = GameSessionSchema.extend({
+  regularCapacityStatus: z.number(),
+  casualCapacityStatus: z.number(),
+})
+
+export const GetGameSessionsWithCapacityStatusResponseSchema = z.object({
+  data: z.array(GameSessionWithCapacityStatusSchema),
+})

--- a/packages/shared/src/types/game-session.ts
+++ b/packages/shared/src/types/game-session.ts
@@ -2,7 +2,9 @@ import type z from "zod"
 import type { GameSession } from "../payload-types"
 import type {
   GameSessionScheduleSchema,
+  GameSessionWithCapacityStatusSchema,
   GetAllGameSessionsBySemesterResponseSchema,
+  GetGameSessionsWithCapacityStatusResponseSchema,
   GetPaginatedGameSessionsResponseSchema,
   UpdateGameSessionRequestSchema,
 } from "../schemas"
@@ -14,6 +16,10 @@ export type GetPaginatedGameSessionsResponse = z.infer<
 >
 export type GetAllGameSessionsBySemesterResponse = z.infer<
   typeof GetAllGameSessionsBySemesterResponseSchema
+>
+export type GameSessionWithCapacityStatus = z.infer<typeof GameSessionWithCapacityStatusSchema>
+export type GetGameSessionsWithCapacityStatusResponse = z.infer<
+  typeof GetGameSessionsWithCapacityStatusResponseSchema
 >
 
 /**


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes towards the related issue. Please also  include relevant context. List any dependencies that are required for this change. -->

I've modified the `api/semesters[id]/game-sessions` route to also return capacity status alongside the sessions. 

Fixes #700 

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added thorough tests that prove my fix is effective and that my feature works
- [x] I've requested a review from another user
