### PR TITLE
fix(bookings): use session openTime for booking check

### DIFF
--- a/apps/backend/src/app/api/bookings/route.test.ts
+++ b/apps/backend/src/app/api/bookings/route.test.ts
@@ -8,7 +8,6 @@ import {
 import {
   casualUserMock,
   gameSessionMock,
-  gameSessionMockBookingNotOpen,
   memberUserMock,
   semesterMock,
   userCreateMock,
@@ -98,29 +97,7 @@ describe("/api/bookings", async () => {
       expect(await res.json()).toStrictEqual({ error: "No remaining sessions" })
     })
 
-    it("should return a 403 if booking is attempted before bookingOpenDay and bookingOpenTime", async () => {
-      cookieStore.set(AUTH_COOKIE_NAME, memberToken)
-
-      // Set system time to Friday July 18, 2025 (before booking opens on Saturday July 19, 2025 at 00:00)
-      vi.setSystemTime(new Date(Date.UTC(2025, 6, 18, 12, 0, 0)))
-
-      try {
-        const req = createMockNextRequest("/api/bookings", "POST", {
-          gameSession: gameSessionMockBookingNotOpen,
-          playerLevel: PlayLevel.beginner,
-        } satisfies CreateBookingRequest)
-        const res = await POST(req)
-
-        expect(res.status).toBe(StatusCodes.FORBIDDEN)
-        expect(await res.json()).toStrictEqual({
-          error: "Booking is not open yet for this session",
-        })
-      } finally {
-        vi.useRealTimers()
-      }
-    })
-
-    it("should return a 403 if booking a session scheduled before the semester's booking open time", async () => {
+    it("should return a 403 if booking a session scheduled before the booking open time", async () => {
       cookieStore.set(AUTH_COOKIE_NAME, memberToken)
       const customSemester = {
         ...semesterMock,
@@ -144,7 +121,7 @@ describe("/api/bookings", async () => {
 
         expect(res.status).toBe(StatusCodes.FORBIDDEN)
         expect(await res.json()).toStrictEqual({
-          error: "Cannot book a session scheduled before the semester's booking open time",
+          error: "Booking is not open yet for this session",
         })
       } finally {
         vi.useRealTimers()

--- a/apps/backend/src/app/api/bookings/route.ts
+++ b/apps/backend/src/app/api/bookings/route.ts
@@ -1,11 +1,4 @@
-import {
-  CreateBookingRequestSchema,
-  calculateOpenDate,
-  MembershipType,
-  type RequestWithUser,
-  type Weekday,
-} from "@repo/shared"
-import type { Semester } from "@repo/shared/payload-types"
+import { CreateBookingRequestSchema, MembershipType, type RequestWithUser } from "@repo/shared"
 import { getReasonPhrase, StatusCodes } from "http-status-codes"
 import { NextResponse } from "next/server"
 import { ZodError } from "zod"
@@ -28,23 +21,12 @@ class RouteWrapper {
         typeof parsedBody.gameSession === "string"
           ? await gameSessionDataService.getGameSessionById(parsedBody.gameSession)
           : parsedBody.gameSession
-      const sessionStartTime = new Date(gameSession.startTime)
-      const openDay = (gameSession.semester as Semester).bookingOpenDay
-      const openTime = new Date((gameSession.semester as Semester).bookingOpenTime)
-
-      const openDate = calculateOpenDate(sessionStartTime, openDay as Weekday, openTime)
+      const sessionStartTime = new Date(gameSession.openTime)
 
       const now = new Date()
-      if (now < openDate) {
+      if (now < sessionStartTime) {
         return NextResponse.json(
           { error: "Booking is not open yet for this session" },
-          { status: StatusCodes.FORBIDDEN },
-        )
-      }
-      // Disallow booking for sessions scheduled before the open date/time
-      if (sessionStartTime < openDate) {
-        return NextResponse.json(
-          { error: "Cannot book a session scheduled before the semester's booking open time" },
           { status: StatusCodes.FORBIDDEN },
         )
       }

--- a/packages/shared/src/mocks/GameSession.mock.ts
+++ b/packages/shared/src/mocks/GameSession.mock.ts
@@ -20,5 +20,5 @@ export const gameSessionMockBookingNotOpen: GameSession = {
   semester: semesterMockBookingNotOpen,
   startTime: new Date(Date.UTC(2025, 6, 21, 9, 0, 0)).toISOString(), // Monday July 21, 2025 at 9am UTC
   endTime: new Date(Date.UTC(2025, 6, 21, 11, 0, 0)).toISOString(), // Monday July 21, 2025 at 11am UTC
-  openTime: new Date(Date.UTC(2025, 6, 21, 8, 0, 0)).toISOString(),
+  openTime: new Date(Date.UTC(2025, 6, 21, 8, 0, 0)).toISOString(), // Monday July 21, 2025 at 8am UTC
 }

--- a/packages/shared/src/mocks/Semester.mock.ts
+++ b/packages/shared/src/mocks/Semester.mock.ts
@@ -9,7 +9,7 @@ export const semesterMock: Semester = {
   breakStart: new Date(Date.UTC(2025, 0, 1, 15, 0)).toISOString(),
   breakEnd: new Date(Date.UTC(2025, 0, 1, 16, 0)).toISOString(),
   bookingOpenDay: Weekday.monday,
-  bookingOpenTime: new Date(Date.UTC(2025, 0, 1, 12, 0)).toISOString(),
+  bookingOpenTime: new Date(Date.UTC(1970, 0, 1, 12, 0)).toISOString(), // 12:00 UTC
   updatedAt: new Date(Date.UTC(2025, 0, 1)).toISOString(),
   createdAt: new Date(Date.UTC(2025, 0, 1)).toISOString(),
 }
@@ -17,5 +17,5 @@ export const semesterMock: Semester = {
 export const semesterMockBookingNotOpen: Semester = {
   ...semesterMock,
   bookingOpenDay: Weekday.saturday,
-  bookingOpenTime: new Date(Date.UTC(2025, 0, 1, 0, 0, 0)).toISOString(), // 00:00 UTC
+  bookingOpenTime: new Date(Date.UTC(1970, 0, 1, 0, 0, 0)).toISOString(), // 00:00 UTC
 }


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes towards the related issue. Please also  include relevant context. List any dependencies that are required for this change. -->

- Fixes #750 

I've fixed bookings to properly look at `openTime` now instead of referencing the semester/game session, etc. 

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added thorough tests that prove my fix is effective and that my feature works
- [x] I've requested a review from another user
