### PR TITLE
fix(auth): add google login prompt on missing password

### DIFF
--- a/apps/backend/src/app/api/auth/login/route.test.ts
+++ b/apps/backend/src/app/api/auth/login/route.test.ts
@@ -82,5 +82,20 @@ describe("api/auth/login", () => {
 
       expect(response.status).toBe(StatusCodes.UNAUTHORIZED)
     })
+
+    it("returns 409 if password is missing and prompts Google login", async () => {
+      await authDataService.createAuth({ ...standardAuthCreateMock, password: undefined })
+      await userDataService.createUser(userCreateMock)
+
+      const req = createMockNextRequest("", "POST", {
+        email: EMAIL_MOCK,
+        password: PASSWORD_MOCK,
+      })
+      const response = await login(req)
+      const body = await response.json()
+
+      expect(response.status).toBe(StatusCodes.CONFLICT)
+      expect(body.error).toBe("Please login with Google")
+    })
   })
 })

--- a/apps/backend/src/app/api/auth/login/route.test.ts
+++ b/apps/backend/src/app/api/auth/login/route.test.ts
@@ -84,7 +84,7 @@ describe("api/auth/login", () => {
     })
 
     it("returns 409 if password is missing and prompts Google login", async () => {
-      await authDataService.createAuth({ ...standardAuthCreateMock, password: undefined })
+      await authDataService.createAuth({ ...standardAuthCreateMock, provider: "google" })
       await userDataService.createUser(userCreateMock)
 
       const req = createMockNextRequest("", "POST", {

--- a/apps/backend/src/app/api/auth/login/route.ts
+++ b/apps/backend/src/app/api/auth/login/route.ts
@@ -36,14 +36,14 @@ export const POST = async (req: NextRequest) => {
     throw error
   }
 
-  if (!auth.password) {
+  if (auth.provider === "google") {
     return NextResponse.json(
       { error: "Please login with Google" },
       { status: StatusCodes.CONFLICT },
     )
   }
 
-  const passwordVerified = await StandardSecurity.verifyPassword(password, auth.password)
+  const passwordVerified = await StandardSecurity.verifyPassword(password, auth.password as string)
   if (!passwordVerified) {
     return NextResponse.json(
       { error: "Invalid email or password" },

--- a/apps/backend/src/app/api/auth/login/route.ts
+++ b/apps/backend/src/app/api/auth/login/route.ts
@@ -36,7 +36,14 @@ export const POST = async (req: NextRequest) => {
     throw error
   }
 
-  const passwordVerified = await StandardSecurity.verifyPassword(password, auth.password as string)
+  if (!auth.password) {
+    return NextResponse.json(
+      { error: "Please login with Google" },
+      { status: StatusCodes.CONFLICT },
+    )
+  }
+
+  const passwordVerified = await StandardSecurity.verifyPassword(password, auth.password)
   if (!passwordVerified) {
     return NextResponse.json(
       { error: "Invalid email or password" },


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes towards the related issue. Please also  include relevant context. List any dependencies that are required for this change. -->

Previously, we'd get a 500 internal server error if a user had a Google account but attempted to login with standard auth (email/password). 

<img width="399" height="194" alt="Screenshot 2025-08-16 at 10 13 00 PM" src="https://github.com/user-attachments/assets/226495b4-b73f-477f-b10a-9dcfe42d656f" />

This PR extends the test coverage for the login route by adding a test case for the "Please login with Google" error, ensuring correct behavior when the password is missing from the authentication record.

> [!NOTE]
> Alternatively, we can enable Google account linking, where if a user signed up with Google, they can add a password to their accounts.

Fixes #751

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added thorough tests that prove my fix is effective and that my feature works
- [x] I've requested a review from another user
