### PR TITLE
fix(register): remove user data from response

### DIFF
--- a/apps/backend/src/app/api/auth/register/route.test.ts
+++ b/apps/backend/src/app/api/auth/register/route.test.ts
@@ -32,7 +32,7 @@ describe("tests /api/auth/register", () => {
     expect(json.message).toBe("User registered successfully")
 
     const user = await userDataService.getUserById(json.data.id)
-    expect(user).toStrictEqual(json.data)
+    expect(user).toBeDefined()
 
     const auth = await authDataService.getAuthByEmail(registerBody.email)
     expect(auth.password).not.toEqual(registerBody.password)

--- a/apps/backend/src/app/api/auth/register/route.test.ts
+++ b/apps/backend/src/app/api/auth/register/route.test.ts
@@ -100,4 +100,15 @@ describe("tests /api/auth/register", () => {
     const json = await res.json()
     expect(json.error).toBe(getReasonPhrase(StatusCodes.INTERNAL_SERVER_ERROR))
   })
+
+  it("should return 500 if getAuthByEmail throws unexpected error", async () => {
+    const error = new Error("Simulated internal error")
+    vi.spyOn(AuthDataService.prototype, "getAuthByEmail").mockRejectedValueOnce(error)
+
+    const res = await POST(createMockNextRequest("", "POST", registerBody))
+
+    expect(res.status).toBe(StatusCodes.INTERNAL_SERVER_ERROR)
+    const json = await res.json()
+    expect(json.error).toBe(getReasonPhrase(StatusCodes.INTERNAL_SERVER_ERROR))
+  })
 })

--- a/apps/backend/src/app/api/auth/register/route.test.ts
+++ b/apps/backend/src/app/api/auth/register/route.test.ts
@@ -31,7 +31,7 @@ describe("tests /api/auth/register", () => {
     const json = await res.json()
     expect(json.message).toBe("User registered successfully")
 
-    const user = await userDataService.getUserById(json.data.id)
+    const user = await userDataService.getUserByEmail(registerBody.email)
     expect(user).toBeDefined()
 
     const auth = await authDataService.getAuthByEmail(registerBody.email)

--- a/apps/backend/src/app/api/auth/register/route.ts
+++ b/apps/backend/src/app/api/auth/register/route.ts
@@ -42,7 +42,7 @@ export const POST = async (req: NextRequest) => {
       password: hash,
     })
     return NextResponse.json(
-      { message: "User registered successfully", data: user },
+      { message: "User registered successfully" },
       {
         status: StatusCodes.CREATED,
       },


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes towards the related issue. Please also  include relevant context. List any dependencies that are required for this change. -->

- Fixes #745

I've removed `user` from register response. This wasn't needed and probably reveals more than what we need to regular users, so it is best to remove it. 

Also added a test to cover the scenario where getAuthByEmail throws an unexpected error in /api/auth/register.

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added thorough tests that prove my fix is effective and that my feature works
- [x] I've requested a review from another user
