### PR TITLE
refactor(theme)!: update theme extension to use extendBaseTheme instead of extendTheme

### DIFF
--- a/packages/theme/src/index.ts
+++ b/packages/theme/src/index.ts
@@ -1,5 +1,5 @@
 import type { ThemeConfig, UsageTheme } from "@yamada-ui/core"
-import { extendConfig, extendTheme } from "@yamada-ui/theme-tools"
+import { extendBaseTheme, extendConfig } from "@yamada-ui/theme-tools"
 import { components } from "./components"
 import { breakpoint, initialColorMode, noticeOptions } from "./config"
 import { semantics } from "./semantics"
@@ -21,6 +21,6 @@ export const defaultTheme: UsageTheme = {
   ...tokens,
 }
 
-export const theme = extendTheme(defaultTheme)()
+export const theme = extendBaseTheme(defaultTheme)()
 
 export { components, semantics, tokens, noticeOptions }

--- a/packages/ui/src/components/Composite/BookingConfirmedPopup/BookingConfirmedPopup.stories.tsx
+++ b/packages/ui/src/components/Composite/BookingConfirmedPopup/BookingConfirmedPopup.stories.tsx
@@ -1,4 +1,4 @@
-import { MembershipType } from "@repo/shared"
+import { MembershipType, Popup } from "@repo/shared"
 import type { Meta, StoryObj } from "@storybook/react"
 import { NuqsAdapter } from "nuqs/adapters/react"
 import { BookingConfirmedPopup } from "./BookingConfirmedPopup"
@@ -15,7 +15,7 @@ const meta: Meta<typeof BookingConfirmedPopup> = {
   ],
   parameters: {
     query: {
-      "booking-confirmed-popup": "open",
+      [Popup.BOOKING_CONFIRMED]: "open",
     },
   },
   args: {

--- a/packages/ui/src/components/Composite/SelectACourt/SelectACourt.stories.tsx
+++ b/packages/ui/src/components/Composite/SelectACourt/SelectACourt.stories.tsx
@@ -27,7 +27,7 @@ export const MemberUser: Story = {
     title: "Select Your Sessions",
     sessions: [
       {
-        date: "Monday, 12th May",
+        date: "2025-05-12T17:00:00.000Z",
         attendees: 32,
         casualAttendees: 4,
         id: "monday-session",
@@ -39,7 +39,7 @@ export const MemberUser: Story = {
         casualCapacity: 5,
       },
       {
-        date: "Wednesday, 14th May",
+        date: "2025-05-14T19:30:00.000Z",
         attendees: 28,
         casualAttendees: 2,
         id: "wednesday-session",
@@ -51,7 +51,7 @@ export const MemberUser: Story = {
         casualCapacity: 5,
       },
       {
-        date: "Thursday, 15th May",
+        date: "2025-05-15T19:30:00.000Z",
         attendees: 25,
         casualAttendees: 3,
         id: "thursday-session",
@@ -63,7 +63,7 @@ export const MemberUser: Story = {
         casualCapacity: 5,
       },
       {
-        date: "Friday, 16th May",
+        date: "2025-05-16T19:30:00.000Z",
         attendees: 30,
         casualAttendees: 1,
         id: "friday-session",
@@ -75,7 +75,7 @@ export const MemberUser: Story = {
         casualCapacity: 5,
       },
       {
-        date: "Saturday, 17th May",
+        date: "2025-05-17T16:00:00.000Z",
         attendees: 20,
         casualAttendees: 2,
         id: "saturday-session",
@@ -102,7 +102,7 @@ export const CasualUser: Story = {
     title: "Choose Your Session",
     sessions: [
       {
-        date: "Monday, 12th May",
+        date: "2025-05-12T17:00:00.000Z",
         attendees: 32,
         casualAttendees: 4,
         id: "monday-casual",
@@ -114,7 +114,7 @@ export const CasualUser: Story = {
         casualCapacity: 5,
       },
       {
-        date: "Wednesday, 14th May",
+        date: "2025-05-14T19:30:00.000Z",
         attendees: 28,
         casualAttendees: 2,
         id: "wednesday-casual",
@@ -126,7 +126,7 @@ export const CasualUser: Story = {
         casualCapacity: 5,
       },
       {
-        date: "Thursday, 15th May",
+        date: "2025-05-15T19:30:00.000Z",
         attendees: 25,
         casualAttendees: 3,
         id: "thursday-casual",
@@ -138,7 +138,7 @@ export const CasualUser: Story = {
         casualCapacity: 5,
       },
       {
-        date: "Friday, 16th May",
+        date: "2025-05-16T19:30:00.000Z",
         attendees: 30,
         casualAttendees: 1,
         id: "friday-casual",
@@ -150,7 +150,7 @@ export const CasualUser: Story = {
         casualCapacity: 5,
       },
       {
-        date: "Saturday, 17th May",
+        date: "2025-05-17T16:00:00.000Z",
         attendees: 20,
         casualAttendees: 2,
         id: "saturday-casual",


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes towards the related issue. Please also  include relevant context. List any dependencies that are required for this change. -->
I have updated `/theme/index.ts` to use the `extendBaseTheme` instead of `extendTheme` to prevent from styling conflict to happen.
I have also fixed few storybook issues we were seeing on the site.

> [!CAUTION]
> THIS IS A BREAKING CHANGE 

`extendBaseTheme` only inherits very basic styles such as `reset-styles` and `global-styles`, and not component specific styles.

Closes #N/A

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)
- [ ] Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added thorough tests that prove my fix is effective and that my feature works
- [x] I've requested a review from another user
