### PR TITLE
fix(auth): change `emailVerificationCode` to optional

### DIFF
--- a/apps/backend/src/app/api/auth/google/callback/route.ts
+++ b/apps/backend/src/app/api/auth/google/callback/route.ts
@@ -1,5 +1,4 @@
 import { GoogleUserInfoResponseSchema, MembershipType, TOKEN_EXPIRY_TIME } from "@repo/shared"
-import { VERIFICATION_CODE_MOCK } from "@repo/shared/mocks"
 import type { User } from "@repo/shared/payload-types"
 import { StatusCodes } from "http-status-codes"
 import { cookies } from "next/headers"
@@ -97,11 +96,6 @@ export const GET = async (req: NextRequest) => {
         lastName: family_name,
         role: MembershipType.casual,
         email,
-        emailVerification: {
-          verificationCode: VERIFICATION_CODE_MOCK,
-          expiresAt: new Date(1970, 1, 1).toISOString(),
-          createdAt: new Date(1970, 1, 1).toISOString(),
-        },
       })
     } else {
       throw error

--- a/apps/backend/src/app/api/auth/register/route.test.ts
+++ b/apps/backend/src/app/api/auth/register/route.test.ts
@@ -80,7 +80,9 @@ describe("tests /api/auth/register", () => {
     const json = await res.json()
 
     expect(res.status).toBe(StatusCodes.BAD_REQUEST)
-    expect(json.error).toBe("Latest email verification code has expired")
+    expect(json.error).toBe(
+      "Latest email verification code has expired. Please request a new code. ",
+    )
   })
 
   it("should return a 403 if the user hasn't created a verification code request", async () => {

--- a/apps/backend/src/app/api/auth/register/route.ts
+++ b/apps/backend/src/app/api/auth/register/route.ts
@@ -30,16 +30,16 @@ export const POST = async (req: NextRequest) => {
     const user = await userDataService.getUserByEmail(email)
 
     if (
-      !user.emailVerification.expiresAt ||
+      !user?.emailVerification?.expiresAt ||
       new Date(user.emailVerification.expiresAt) < new Date()
     ) {
       return NextResponse.json(
-        { error: "Latest email verification code has expired" },
+        { error: "Latest email verification code has expired. Please request a new code. " },
         { status: StatusCodes.BAD_REQUEST },
       )
     }
 
-    if (user.emailVerification.verificationCode !== emailVerificationCode) {
+    if (user?.emailVerification?.verificationCode !== emailVerificationCode) {
       return NextResponse.json(
         { error: "Invalid email verification code" },
         { status: StatusCodes.BAD_REQUEST },

--- a/apps/backend/src/data-layer/collections/User.ts
+++ b/apps/backend/src/data-layer/collections/User.ts
@@ -120,12 +120,11 @@ export const User: CollectionConfig = {
       name: "emailVerification",
       interfaceName: "EmailVerification",
       type: "group",
-      required: true,
+      required: false,
       fields: [
         {
           name: "verificationCode",
           type: "text",
-          required: true,
           admin: {
             description: "The most recent verification code for the user",
           },
@@ -133,7 +132,6 @@ export const User: CollectionConfig = {
         {
           name: "expiresAt",
           type: "date",
-          required: true,
           admin: {
             date: {
               pickerAppearance: "dayAndTime",
@@ -144,7 +142,6 @@ export const User: CollectionConfig = {
         {
           name: "createdAt",
           type: "date",
-          required: true,
           admin: {
             date: {
               pickerAppearance: "dayAndTime",

--- a/packages/shared/src/payload-types.ts
+++ b/packages/shared/src/payload-types.ts
@@ -374,7 +374,7 @@ export interface User {
    * The image of the user
    */
   image?: (string | null) | Media;
-  emailVerification: EmailVerification;
+  emailVerification?: EmailVerification;
   updatedAt: string;
   createdAt: string;
 }
@@ -388,15 +388,15 @@ export interface EmailVerification {
   /**
    * The most recent verification code for the user
    */
-  verificationCode: string;
+  verificationCode?: string | null;
   /**
    * The current expiration date of this email verification code
    */
-  expiresAt: string;
+  expiresAt?: string | null;
   /**
    * The date when this email verification code was created
    */
-  createdAt: string;
+  createdAt?: string | null;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/packages/shared/src/schemas/user.ts
+++ b/packages/shared/src/schemas/user.ts
@@ -14,9 +14,17 @@ import { PaginationDataSchema } from "./query"
 
 export const EmailVerificationCodeSchema = z.object({
   id: z.string().nullable().optional(),
-  verificationCode: z.string(),
-  createdAt: z.string().datetime({ message: "Invalid date format, should be in ISO 8601 format" }),
-  expiresAt: z.string().datetime({ message: "Invalid date format, should be in ISO 8601 format" }),
+  verificationCode: z.string().nullable().optional(),
+  createdAt: z
+    .string()
+    .datetime({ message: "Invalid date format, should be in ISO 8601 format" })
+    .nullable()
+    .optional(),
+  expiresAt: z
+    .string()
+    .datetime({ message: "Invalid date format, should be in ISO 8601 format" })
+    .nullable()
+    .optional(),
 }) satisfies z.ZodType<EmailVerification>
 
 export const UserSchema = z.object({
@@ -24,7 +32,7 @@ export const UserSchema = z.object({
   firstName: z.string(),
   lastName: z.string().nullable().optional(),
   email: z.string().email(),
-  emailVerification: EmailVerificationCodeSchema,
+  emailVerification: EmailVerificationCodeSchema.optional(),
   phoneNumber: z.string().nullable().optional(),
   // Payload generates a hard coded role type, the `satisfies` operator is used to ensure the type matches
   role: z.enum(["admin", "member", "casual"]),


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes towards the related issue. Please also  include relevant context. List any dependencies that are required for this change. -->

- Fixes #593 

I fixed the problem where existing accounts would break our auth system by failing auth schema parsing. This has been fixed by changing the verification code to be optional instead of a required field. 

I've also updated the register route to adapt to these changes. 

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added thorough tests that prove my fix is effective and that my feature works
- [x] I've requested a review from another user
