### PR TITLE
fix(game-session-schedules): change cascade open day to week earlier

### DIFF
--- a/apps/backend/src/data-layer/services/GameSessionDataService.test.ts
+++ b/apps/backend/src/data-layer/services/GameSessionDataService.test.ts
@@ -54,11 +54,9 @@ describe("GameSessionDataService", () => {
         const openDate = new Date(session.openTime)
         const semesterBookingOpenTime = new Date(newSemester.bookingOpenTime)
 
-        const normalOpenDate = getGameSessionOpenDay(newSemester, sessionDate)
+        const expectedOpenDate = getGameSessionOpenDay(newSemester, sessionDate)
 
-        // open date should be exactly 7 days before the booking open date (of same week)
-        const weekInMs = 7 * 24 * 60 * 60 * 1000
-        const expectedOpenDate = new Date(normalOpenDate.getTime() - weekInMs)
+        // open date should match the result of getGameSessionOpenDay
         expect(openDate.getUTCFullYear()).toBe(expectedOpenDate.getUTCFullYear())
         expect(openDate.getUTCMonth()).toBe(expectedOpenDate.getUTCMonth())
         expect(openDate.getUTCDate()).toBe(expectedOpenDate.getUTCDate())

--- a/apps/backend/src/data-layer/services/GameSessionDataService.ts
+++ b/apps/backend/src/data-layer/services/GameSessionDataService.ts
@@ -1,7 +1,7 @@
 import {
   type CreateGameSessionData,
   type CreateGameSessionScheduleData,
-  getGameSessionOpenDateOneWeekEarlier,
+  getGameSessionOpenDay,
   TimeframeFilter,
   type UpdateGameSessionData,
   type UpdateGameSessionScheduleData,
@@ -211,7 +211,7 @@ export default class GameSessionDataService {
         ...gameSessionTimes,
         capacity: schedule.capacity,
         casualCapacity: schedule.casualCapacity,
-        openTime: getGameSessionOpenDateOneWeekEarlier(
+        openTime: getGameSessionOpenDay(
           semester,
           new Date(gameSessionTimes.startTime),
         ).toISOString(),

--- a/apps/backend/src/utils/date.test.ts
+++ b/apps/backend/src/utils/date.test.ts
@@ -1,7 +1,6 @@
 import {
   calculateOpenDate,
   getDaysBetweenWeekdays,
-  getGameSessionOpenDateOneWeekEarlier,
   getGameSessionOpenDay,
   Weekday,
 } from "@repo/shared"
@@ -118,7 +117,7 @@ describe("getGameSessionOpenDay", () => {
     const startTime = new Date(Date.UTC(2024, 0, 15, 14, 0, 0)) // Monday
 
     const result = getGameSessionOpenDay(semester, startTime)
-    const expected = new Date(Date.UTC(2024, 0, 12, 9, 0, 0))
+    const expected = new Date(Date.UTC(2024, 0, 5, 9, 0, 0))
     expect(result).toEqual(expected)
   })
 
@@ -131,11 +130,11 @@ describe("getGameSessionOpenDay", () => {
     const startTime = new Date(Date.UTC(2024, 0, 21, 15, 0, 0)) // Sunday
 
     const result = getGameSessionOpenDay(semester, startTime)
-    const expected = new Date(Date.UTC(2024, 0, 17, 10, 0, 0))
+    const expected = new Date(Date.UTC(2024, 0, 10, 10, 0, 0))
     expect(result).toEqual(expected)
   })
 
-  it("should calculate the correct open date when session and open day are the same", () => {
+  it("should calculate the open date one week before when session and open day are the same", () => {
     const semester: Semester = {
       ...semesterMock,
       bookingOpenDay: Weekday.tuesday,
@@ -144,7 +143,7 @@ describe("getGameSessionOpenDay", () => {
     const startTime = new Date(Date.UTC(2024, 0, 16, 13, 0, 0)) // Tuesday
 
     const result = getGameSessionOpenDay(semester, startTime)
-    const expected = new Date(Date.UTC(2024, 0, 16, 8, 0, 0))
+    const expected = new Date(Date.UTC(2024, 0, 9, 8, 0, 0))
     expect(result).toEqual(expected)
   })
 
@@ -157,7 +156,7 @@ describe("getGameSessionOpenDay", () => {
     const startTime = new Date(Date.UTC(2024, 0, 20, 16, 0, 0)) // Saturday
 
     const result = getGameSessionOpenDay(semester, startTime)
-    const expected = new Date(Date.UTC(2024, 0, 18, 14, 30, 45)) // Thursday before
+    const expected = new Date(Date.UTC(2024, 0, 11, 14, 30, 45)) // Thursday
     expect(result).toEqual(expected)
   })
 
@@ -170,91 +169,7 @@ describe("getGameSessionOpenDay", () => {
     const startTime = new Date(Date.UTC(2024, 0, 18, 18, 0, 0)) // Thursday
 
     const result = getGameSessionOpenDay(semester, startTime)
-    const expected = new Date(Date.UTC(2024, 0, 15, 12, 0, 0)) // Monday before
-    expect(result).toEqual(expected)
-  })
-})
-
-describe("getGameSessionOpenDateOneWeekEarlier", () => {
-  it("should calculate the correct open date and be one week for a Monday session", () => {
-    const semester: Semester = {
-      ...semesterMock,
-      bookingOpenDay: Weekday.friday,
-      bookingOpenTime: new Date(Date.UTC(2024, 0, 1, 9, 0, 0)).toISOString(), // 9 AM
-    }
-    const startTime = new Date(Date.UTC(2024, 0, 15, 14, 0, 0)) // Monday Jan 15
-
-    const result = getGameSessionOpenDateOneWeekEarlier(semester, startTime)
-    // Friday Jan 12, one week earlier is Friday Jan 5
-    const expected = new Date(Date.UTC(2024, 0, 5, 9, 0, 0))
-    expect(result).toEqual(expected)
-  })
-
-  it("should calculate the correct open date and be one week for a Friday session", () => {
-    const semester: Semester = {
-      ...semesterMock,
-      bookingOpenDay: Weekday.monday,
-      bookingOpenTime: new Date(Date.UTC(2024, 0, 1, 10, 30, 0)).toISOString(), // 10:30 AM
-    }
-    const startTime = new Date(Date.UTC(2024, 0, 19, 18, 0, 0)) // Friday Jan 19
-
-    const result = getGameSessionOpenDateOneWeekEarlier(semester, startTime)
-    // Monday Jan 15, one week earlier is Monday Jan 8
-    const expected = new Date(Date.UTC(2024, 0, 8, 10, 30, 0))
-    expect(result).toEqual(expected)
-  })
-
-  it("should calculate the open date one week before the normal booking open day for a Sunday session", () => {
-    const semester: Semester = {
-      ...semesterMock,
-      bookingOpenDay: Weekday.wednesday,
-      bookingOpenTime: new Date(Date.UTC(2024, 0, 1, 8, 15, 30)).toISOString(), // 8:15:30 AM
-    }
-    const startTime = new Date(Date.UTC(2024, 0, 21, 15, 0, 0)) // Sunday Jan 21
-
-    const result = getGameSessionOpenDateOneWeekEarlier(semester, startTime)
-    // Wednesday Jan 17, so one week earlier is Wednesday Jan 10
-    const expected = new Date(Date.UTC(2024, 0, 10, 8, 15, 30))
-    expect(result).toEqual(expected)
-  })
-
-  it("should preserve the exact time from bookingOpenTime", () => {
-    const semester: Semester = {
-      ...semesterMock,
-      bookingOpenDay: Weekday.thursday,
-      bookingOpenTime: new Date(Date.UTC(2024, 0, 1, 14, 30, 45)).toISOString(), // 2:30:45 PM
-    }
-    const startTime = new Date(Date.UTC(2024, 0, 20, 20, 0, 0)) // Saturday Jan 20 at 8 PM
-
-    const result = getGameSessionOpenDateOneWeekEarlier(semester, startTime)
-    const expected = new Date(Date.UTC(2024, 0, 11, 14, 30, 45))
-    expect(result).toEqual(expected)
-  })
-
-  it("should handle bookingOpenTime as a string", () => {
-    const semester: Semester = {
-      ...semesterMock,
-      bookingOpenDay: Weekday.monday,
-      bookingOpenTime: "2024-01-01T12:00:00.000Z",
-    }
-    const startTime = new Date(Date.UTC(2024, 0, 18, 16, 0, 0)) // Thursday Jan 18
-
-    const result = getGameSessionOpenDateOneWeekEarlier(semester, startTime)
-    const expected = new Date(Date.UTC(2024, 0, 8, 12, 0, 0))
-    expect(result).toEqual(expected)
-  })
-
-  it("should work across month boundaries", () => {
-    const semester: Semester = {
-      ...semesterMock,
-      bookingOpenDay: Weekday.friday,
-      bookingOpenTime: new Date(Date.UTC(2024, 0, 1, 11, 0, 0)).toISOString(), // 11 AM
-    }
-    const startTime = new Date(Date.UTC(2024, 1, 5, 19, 0, 0)) // Monday Feb 5
-
-    const result = getGameSessionOpenDateOneWeekEarlier(semester, startTime)
-    // Normal booking open would be Friday Feb 2, so one week earlier is Friday Jan 26
-    const expected = new Date(Date.UTC(2024, 0, 26, 11, 0, 0))
+    const expected = new Date(Date.UTC(2024, 0, 8, 12, 0, 0)) // Monday
     expect(result).toEqual(expected)
   })
 })

--- a/packages/shared/src/utils/date.ts
+++ b/packages/shared/src/utils/date.ts
@@ -66,7 +66,7 @@ export function getGameSessionOpenDay(semester: Semester, startTime: Date): Date
 
   const dayIndex = startTime.getUTCDay()
   const day = Object.values(Weekday)[dayIndex] as Weekday
-  const daysToSubtract = getDaysBetweenWeekdays(bookingOpenDay as Weekday, day)
+  const daysToSubtract = getDaysBetweenWeekdays(bookingOpenDay as Weekday, day) + 7
 
   openDate.setUTCDate(startTime.getUTCDate() - daysToSubtract)
   openDate.setUTCHours(
@@ -77,25 +77,6 @@ export function getGameSessionOpenDay(semester: Semester, startTime: Date): Date
   )
 
   return openDate
-}
-
-/**
- * Calculates the open date for a game session to be exactly one week (7 days) earlier
- * than the session start time, preserving the semester's booking open time.
- *
- * @param semester The {@link Semester} object containing booking open time
- * @param startTime The start time of the game session
- * @returns The calculated booking open date exactly one week earlier
- */
-export function getGameSessionOpenDateOneWeekEarlier(semester: Semester, startTime: Date): Date {
-  // First, get the normal booking open date using existing logic
-  const normalOpenDate = getGameSessionOpenDay(semester, startTime)
-
-  // Then subtract exactly 7 days from that date
-  const oneWeekEarlierDate = new Date(normalOpenDate)
-  oneWeekEarlierDate.setUTCDate(normalOpenDate.getUTCDate() - 7)
-
-  return oneWeekEarlierDate
 }
 
 /**


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes towards the related issue. Please also  include relevant context. List any dependencies that are required for this change. -->

- Fixes #807 

I've fixed the `POST /api/admin/game-session-schedules` endpoint cascade creation logic. It was creating game session open date/times within the same week which was incorrect, it should have created them a week earlier. 

The problem arises where an open time may be later than the actual start time of a session (see image below):

<img width="318" height="128" alt="Screenshot 2025-09-11 at 11 57 17 PM" src="https://github.com/user-attachments/assets/c1f409d3-44c8-4b92-8f30-fe0ee73e07aa" />

Changes: 
- Update GameSessionDataService to use new open date calculation
- Add comprehensive tests for getGameSessionOpenDateOneWeekEarlier
- Refactor tests to verify open date is exactly one week earlier

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added thorough tests that prove my fix is effective and that my feature works
- [x] I've requested a review from another user
