### PR TITLE
fix(bookings-api): enforce max user bookings in a week

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -7,12 +7,8 @@
       "format_on_save": "on"
     }
   },
-  "language_servers": [
-    "...",
-    "!typescript-language-server",
-    "!eslint",
-    "!tailwindcss-language-server"
-  ],
+  // cspell:disable-next-line
+  "language_servers": ["...", "!vtsls", "!eslint", "!tailwindcss-language-server"],
   "formatter": {
     "language_server": {
       "name": "biome"

--- a/apps/backend/src/app/api/bookings/route.test.ts
+++ b/apps/backend/src/app/api/bookings/route.test.ts
@@ -169,7 +169,11 @@ describe("/api/bookings", async () => {
 
     it("should call the booking confirmation email service", async () => {
       cookieStore.set(AUTH_COOKIE_NAME, casualToken)
-      const gameSession = await gameSessionDataService.createGameSession(gameSessionCreateMock)
+      const semester = await semesterDataService.createSemester(currentSemesterCreateMock)
+      const gameSession = await gameSessionDataService.createGameSession({
+        ...gameSessionCreateMock,
+        semester,
+      })
       const sendBookingConfirmationSpy = vi
         .spyOn(MailService, "sendBookingConfirmation")
         .mockResolvedValueOnce({ success: true })

--- a/apps/backend/src/app/api/bookings/route.test.ts
+++ b/apps/backend/src/app/api/bookings/route.test.ts
@@ -312,6 +312,21 @@ describe("/api/bookings", async () => {
     })
   })
 
+  it("should return a 404 if there is no current semester", async () => {
+    cookieStore.set(AUTH_COOKIE_NAME, memberToken)
+
+    const gameSession = await gameSessionDataService.createGameSession(gameSessionCreateMock)
+
+    const req = createMockNextRequest("", "POST", {
+      gameSession,
+      playerLevel: PlayLevel.beginner,
+    } satisfies CreateBookingRequest)
+    const res = await POST(req)
+
+    expect(res.status).toBe(StatusCodes.NOT_FOUND)
+    expect(await res.json()).toStrictEqual({ error: "Booking semester not found" })
+  })
+
   it("should return 400 if request body is invalid", async () => {
     cookieStore.set(AUTH_COOKIE_NAME, adminToken)
 

--- a/apps/backend/src/app/api/bookings/route.test.ts
+++ b/apps/backend/src/app/api/bookings/route.test.ts
@@ -1,6 +1,7 @@
 import {
   AUTH_COOKIE_NAME,
   type CreateBookingRequest,
+  type CreateSemesterData,
   MembershipType,
   PlayLevel,
   Weekday,
@@ -16,20 +17,31 @@ import { getReasonPhrase, StatusCodes } from "http-status-codes"
 import { cookies } from "next/headers"
 import BookingDataService from "@/data-layer/services/BookingDataService"
 import GameSessionDataService from "@/data-layer/services/GameSessionDataService"
+import SemesterDataService from "@/data-layer/services/SemesterDataService"
 import UserDataService from "@/data-layer/services/UserDataService"
 import { createMockNextRequest } from "@/test-config/backend-utils"
 import { bookingCreateMock } from "@/test-config/mocks/Booking.mock"
 import { gameSessionCreateMock } from "@/test-config/mocks/GameSession.mock"
+import { semesterCreateMock } from "@/test-config/mocks/Semester.mock"
 import { adminToken, casualToken, memberToken } from "@/test-config/vitest.setup"
 import { POST } from "./route"
 
 describe("/api/bookings", async () => {
   const cookieStore = await cookies()
   const bookingDataService = new BookingDataService()
+  const semesterDataService = new SemesterDataService()
   const gameSessionDataService = new GameSessionDataService()
   const userDataService = new UserDataService()
 
   describe("POST", () => {
+    const now = new Date()
+
+    const currentSemesterCreateMock: CreateSemesterData = {
+      ...semesterCreateMock,
+      startDate: new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 1, 1)).toISOString(),
+      endDate: new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 4, 0)).toISOString(),
+    }
+
     it("should return a 401 if token is missing", async () => {
       const res = await POST(createMockNextRequest())
       expect(res.status).toBe(StatusCodes.UNAUTHORIZED)
@@ -38,7 +50,12 @@ describe("/api/bookings", async () => {
 
     it("should return a 201 if the booking is valid", async () => {
       cookieStore.set(AUTH_COOKIE_NAME, memberToken)
-      const gameSession = await gameSessionDataService.createGameSession(gameSessionCreateMock)
+
+      const semester = await semesterDataService.createSemester(currentSemesterCreateMock)
+      const gameSession = await gameSessionDataService.createGameSession({
+        ...gameSessionCreateMock,
+        semester,
+      })
       const remainingSessions = memberUserMock.remainingSessions ?? 0
       const newRemainingSessions = remainingSessions - 1
 
@@ -59,6 +76,95 @@ describe("/api/bookings", async () => {
       if (newRemainingSessions <= 0) {
         expect(user.role).toBe(MembershipType.casual)
       }
+    })
+
+    it("should return a 403 if a member has reached their max number of bookings per week", async () => {
+      cookieStore.set(AUTH_COOKIE_NAME, memberToken)
+
+      const currentSemester = await semesterDataService.createSemester(currentSemesterCreateMock)
+
+      const startTime = new Date(now)
+      startTime.setUTCMinutes(now.getUTCMinutes() + 1)
+      const endTime = new Date(startTime)
+      endTime.setUTCMinutes(now.getUTCMinutes() + 59)
+
+      const gameSession = await gameSessionDataService.createGameSession({
+        ...gameSessionCreateMock,
+        startTime: startTime.toISOString(),
+        endTime: endTime.toISOString(),
+        semester: currentSemester,
+      })
+      const gameSession2 = await gameSessionDataService.createGameSession({
+        ...gameSessionCreateMock,
+        startTime: startTime.toISOString(),
+        endTime: endTime.toISOString(),
+        semester: currentSemester,
+      })
+      const gameSession3 = await gameSessionDataService.createGameSession({
+        ...gameSessionCreateMock,
+        startTime: startTime.toISOString(),
+        endTime: endTime.toISOString(),
+        semester: currentSemester,
+      })
+
+      await bookingDataService.createBooking({
+        ...bookingCreateMock,
+        gameSession: gameSession.id,
+        user: memberUserMock,
+      })
+      await bookingDataService.createBooking({
+        ...bookingCreateMock,
+        gameSession: gameSession2.id,
+        user: memberUserMock,
+      })
+
+      const req = createMockNextRequest("/api/bookings", "POST", {
+        gameSession: gameSession3,
+        playerLevel: PlayLevel.beginner,
+      } satisfies CreateBookingRequest)
+
+      const res = await POST(req)
+      expect(res.status).toBe(StatusCodes.FORBIDDEN)
+      expect(await res.json()).toStrictEqual({ error: "Weekly booking limit reached" })
+    })
+
+    it("should return a 403 if a member has reached their max number of bookings per week", async () => {
+      cookieStore.set(AUTH_COOKIE_NAME, casualToken)
+
+      const currentSemester = await semesterDataService.createSemester(currentSemesterCreateMock)
+
+      const startTime = new Date(now)
+      startTime.setUTCMinutes(now.getUTCMinutes() + 1)
+      const endTime = new Date(startTime)
+      endTime.setUTCMinutes(now.getUTCMinutes() + 59)
+
+      const gameSession = await gameSessionDataService.createGameSession({
+        ...gameSessionCreateMock,
+        startTime: startTime.toISOString(),
+        endTime: endTime.toISOString(),
+        semester: currentSemester,
+      })
+      const gameSession2 = await gameSessionDataService.createGameSession({
+        ...gameSessionCreateMock,
+        startTime: startTime.toISOString(),
+        endTime: endTime.toISOString(),
+        semester: currentSemester,
+      })
+
+      await bookingDataService.createBooking({
+        ...bookingCreateMock,
+        gameSession: gameSession.id,
+        user: casualUserMock,
+      })
+
+      const req = createMockNextRequest("/api/bookings", "POST", {
+        gameSession: gameSession2,
+        playerLevel: PlayLevel.beginner,
+      } satisfies CreateBookingRequest)
+
+      const res = await POST(req)
+      expect(res.status).toBe(StatusCodes.FORBIDDEN)
+      expect(await res.json()).toStrictEqual({ error: "Weekly booking limit reached" })
     })
 
     it("should return a 409 if the user has already made a booking for the session", async () => {

--- a/apps/backend/src/app/api/bookings/route.test.ts
+++ b/apps/backend/src/app/api/bookings/route.test.ts
@@ -89,24 +89,22 @@ describe("/api/bookings", async () => {
       const endTime = new Date(startTime)
       endTime.setUTCMinutes(now.getUTCMinutes() + 59)
 
-      const gameSession = await gameSessionDataService.createGameSession({
+      const futureGameSessionCreateMock = {
         ...gameSessionCreateMock,
         startTime: startTime.toISOString(),
         endTime: endTime.toISOString(),
         semester: currentSemester,
-      })
-      const gameSession2 = await gameSessionDataService.createGameSession({
-        ...gameSessionCreateMock,
-        startTime: startTime.toISOString(),
-        endTime: endTime.toISOString(),
-        semester: currentSemester,
-      })
-      const gameSession3 = await gameSessionDataService.createGameSession({
-        ...gameSessionCreateMock,
-        startTime: startTime.toISOString(),
-        endTime: endTime.toISOString(),
-        semester: currentSemester,
-      })
+      }
+
+      const gameSession = await gameSessionDataService.createGameSession(
+        futureGameSessionCreateMock,
+      )
+      const gameSession2 = await gameSessionDataService.createGameSession(
+        futureGameSessionCreateMock,
+      )
+      const gameSession3 = await gameSessionDataService.createGameSession(
+        futureGameSessionCreateMock,
+      )
 
       await bookingDataService.createBooking({
         ...bookingCreateMock,
@@ -139,18 +137,19 @@ describe("/api/bookings", async () => {
       const endTime = new Date(startTime)
       endTime.setUTCMinutes(now.getUTCMinutes() + 59)
 
-      const gameSession = await gameSessionDataService.createGameSession({
+      const futureGameSessionCreateMock = {
         ...gameSessionCreateMock,
         startTime: startTime.toISOString(),
         endTime: endTime.toISOString(),
         semester: currentSemester,
-      })
-      const gameSession2 = await gameSessionDataService.createGameSession({
-        ...gameSessionCreateMock,
-        startTime: startTime.toISOString(),
-        endTime: endTime.toISOString(),
-        semester: currentSemester,
-      })
+      }
+
+      const gameSession = await gameSessionDataService.createGameSession(
+        futureGameSessionCreateMock,
+      )
+      const gameSession2 = await gameSessionDataService.createGameSession(
+        futureGameSessionCreateMock,
+      )
 
       await bookingDataService.createBooking({
         ...bookingCreateMock,

--- a/apps/backend/src/app/api/bookings/route.ts
+++ b/apps/backend/src/app/api/bookings/route.ts
@@ -6,6 +6,7 @@ import {
 } from "@repo/shared"
 import { getReasonPhrase, StatusCodes } from "http-status-codes"
 import { NextResponse } from "next/server"
+import { NotFound } from "payload"
 import { ZodError } from "zod"
 import { Security } from "@/business-layer/middleware/Security"
 import MailService from "@/business-layer/services/MailService"
@@ -99,6 +100,12 @@ class RouteWrapper {
 
       return NextResponse.json({ data: newBooking }, { status: StatusCodes.CREATED })
     } catch (error) {
+      if (error instanceof NotFound) {
+        return NextResponse.json(
+          { error: "Booking semester not found" },
+          { status: StatusCodes.NOT_FOUND },
+        )
+      }
       if (error instanceof ZodError) {
         return NextResponse.json(
           { error: "Invalid request body", details: error.flatten() },

--- a/apps/backend/src/data-layer/services/BookingDataService.test.ts
+++ b/apps/backend/src/data-layer/services/BookingDataService.test.ts
@@ -1,4 +1,4 @@
-import type { EditBookingData } from "@repo/shared"
+import type { CreateSemesterData, EditBookingData } from "@repo/shared"
 import { casualUserMock } from "@repo/shared/mocks"
 import { bookingCreateMock, bookingCreateMock2 } from "@/test-config/mocks/Booking.mock"
 import { gameSessionCreateMock } from "@/test-config/mocks/GameSession.mock"
@@ -122,6 +122,86 @@ describe("bookingDataService", () => {
     it("should return empty array if there are no bookings by userId", async () => {
       const fetchedBooking = await bookingDataService.getAllBookingsByUserId("No bookings userId")
       expect(fetchedBooking).toStrictEqual([])
+    })
+  })
+
+  describe("getAllCurrentWeekBookingsByUserId", () => {
+    const now = new Date()
+
+    // Booking start weekday is Monday
+    const currentSemesterCreateMock: CreateSemesterData = {
+      ...semesterCreateMock,
+      startDate: new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 1, 1)).toISOString(),
+      endDate: new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 4, 0)).toISOString(),
+    }
+
+    it("should fetch all bookings within a booking week period", async () => {
+      const semester = await semesterDataService.createSemester(currentSemesterCreateMock)
+
+      const startTime = new Date(now)
+      startTime.setUTCMinutes(now.getUTCMinutes() + 1)
+      const endTime = new Date(startTime)
+      endTime.setUTCMinutes(now.getUTCMinutes() + 59)
+
+      const gameSession1 = await gameSessionDataService.createGameSession({
+        ...gameSessionCreateMock,
+        startTime: startTime.toISOString(),
+        endTime: endTime.toISOString(),
+        semester: semester.id,
+      })
+      const gameSession2 = await gameSessionDataService.createGameSession({
+        ...gameSessionCreateMock,
+        startTime: startTime.toISOString(),
+        endTime: endTime.toISOString(),
+        semester: semester.id,
+      })
+
+      const booking1 = await bookingDataService.createBooking({
+        ...bookingCreateMock,
+        user: casualUserMock,
+        gameSession: gameSession1.id,
+      })
+      const booking2 = await bookingDataService.createBooking({
+        ...bookingCreateMock,
+        user: casualUserMock,
+        gameSession: gameSession2.id,
+      })
+
+      const fetchedBookings = await bookingDataService.getAllCurrentWeekBookingsByUserId(
+        casualUserMock.id,
+        semester,
+      )
+      expect(fetchedBookings.length).toStrictEqual(2)
+      expect(fetchedBookings).toEqual(expect.arrayContaining([booking1, booking2]))
+    })
+
+    it("should not fetch bookings outside of the current booking week period", async () => {
+      const semester = await semesterDataService.createSemester(currentSemesterCreateMock)
+
+      // Set start and open time to a week ago
+      const startTime = new Date(now)
+      startTime.setUTCDate(now.getUTCDate() - 9)
+      const endTime = new Date(startTime)
+      endTime.setUTCDate(now.getUTCDate() - 8)
+
+      const gameSession = await gameSessionDataService.createGameSession({
+        ...gameSessionCreateMock,
+        startTime: startTime.toISOString(),
+        endTime: endTime.toISOString(),
+        semester: semester.id,
+      })
+
+      await bookingDataService.createBooking({
+        ...bookingCreateMock,
+        user: casualUserMock,
+        gameSession: gameSession.id,
+      })
+
+      const fetchedBookings = await bookingDataService.getAllCurrentWeekBookingsByUserId(
+        casualUserMock.id,
+        semester,
+      )
+      expect(fetchedBookings.length).toStrictEqual(0)
     })
   })
 

--- a/apps/backend/src/data-layer/services/BookingDataService.ts
+++ b/apps/backend/src/data-layer/services/BookingDataService.ts
@@ -1,5 +1,10 @@
-import type { CreateBookingData, EditBookingData } from "@repo/shared"
-import type { Booking } from "@repo/shared/payload-types"
+import {
+  type CreateBookingData,
+  type EditBookingData,
+  getDaysBetweenWeekdays,
+  Weekday,
+} from "@repo/shared"
+import type { Booking, Semester } from "@repo/shared/payload-types"
 import type { PaginatedDocs } from "payload"
 import { NotFound } from "payload"
 import { payload } from "@/data-layer/adapters/Payload"
@@ -124,6 +129,60 @@ export default class BookingDataService {
         pagination: false,
       })
     ).docs
+  }
+
+  /**
+   * Finds all {@link Booking} documents for the current booking week by a {@link User}'s id
+   *
+   * The current booking week is determined by the `bookingOpenDay` and `bookingOpenTime` of the provided {@link Semester}.
+   * Bookings are fetched for the 7-day period starting from the most recent occurrence of the `bookingOpenDay` and `bookingOpenTime`.
+   *
+   * @param userId The ID of the user whose {@link Booking} you find
+   * @param semester The {@link Semester} to determine the booking week
+   *
+   * @returns all {@link Booking} documents within the current booking week, otherwise returns an empty array
+   */
+  public async getAllCurrentWeekBookingsByUserId(
+    userId: string,
+    semester: Semester,
+  ): Promise<Booking[]> {
+    const now = new Date()
+    const todayWeekday = Object.values(Weekday)[now.getUTCDay()]
+
+    const { bookingOpenDay, bookingOpenTime } = semester
+
+    const daysDifference = getDaysBetweenWeekdays(bookingOpenDay as Weekday, todayWeekday)
+
+    const bookingStartPeriod = new Date(bookingOpenTime)
+    bookingStartPeriod.setUTCFullYear(
+      now.getUTCFullYear(),
+      now.getUTCMonth(),
+      now.getUTCDate() - daysDifference,
+    )
+
+    const bookingEndPeriod = new Date(bookingStartPeriod)
+    bookingEndPeriod.setUTCDate(bookingStartPeriod.getUTCDate() + 7)
+
+    const { docs } = await payload.find({
+      collection: "booking",
+      pagination: false,
+      where: {
+        and: [
+          {
+            user: {
+              equals: userId,
+            },
+          },
+          {
+            "gameSession.startTime": {
+              greater_than: bookingStartPeriod.toISOString(),
+              less_than: bookingEndPeriod.toISOString(),
+            },
+          },
+        ],
+      },
+    })
+    return docs
   }
 
   /**

--- a/apps/backend/src/data-layer/services/BookingDataService.ts
+++ b/apps/backend/src/data-layer/services/BookingDataService.ts
@@ -175,7 +175,7 @@ export default class BookingDataService {
           },
           {
             "gameSession.startTime": {
-              greater_than: bookingStartPeriod.toISOString(),
+              greater_than_equal: bookingStartPeriod.toISOString(),
               less_than: bookingEndPeriod.toISOString(),
             },
           },

--- a/apps/backend/src/data-layer/services/GameSessionDataService.ts
+++ b/apps/backend/src/data-layer/services/GameSessionDataService.ts
@@ -113,6 +113,7 @@ export default class GameSessionDataService {
    * Gets all {@link GameSession} documents for a given semester ID
    *
    * @param semesterId the ID of the {@link Semester} to get game sessions for
+   * @param timeframe optional filter to get upcoming, past, or current game sessions only
    * @returns an array of {@link GameSession} documents
    */
   public async getGameSessionsBySemesterId(

--- a/apps/backend/src/data-layer/utils/DateUtils.ts
+++ b/apps/backend/src/data-layer/utils/DateUtils.ts
@@ -38,8 +38,8 @@ export function getWeeklySessionDates(day: Weekday, semester: Semester): Date[] 
  * @returns Both startTime and endTime of the game session
  */
 export function createGameSessionTimes(schedule: GameSessionSchedule, date: Date) {
-  const day = date.getDate()
-  const month = date.getMonth()
+  const day = date.getUTCDate()
+  const month = date.getUTCMonth()
   const year = date.getFullYear()
 
   const start = new Date(schedule.startTime)

--- a/apps/backend/src/test-config/mocks/Semester.mock.ts
+++ b/apps/backend/src/test-config/mocks/Semester.mock.ts
@@ -8,7 +8,7 @@ export const semesterCreateMock: CreateSemesterData = {
   breakStart: new Date(2025, 0, 1, 15, 0).toISOString(),
   breakEnd: new Date(2025, 0, 1, 16, 0).toISOString(),
   bookingOpenDay: Weekday.monday,
-  bookingOpenTime: new Date(2025, 0, 1, 12, 0).toISOString(),
+  bookingOpenTime: new Date(1970, 0, 1, 12, 0).toISOString(), // 12pm
 }
 
 export const semesterMock: Semester = {
@@ -19,7 +19,7 @@ export const semesterMock: Semester = {
   breakStart: new Date(2025, 0, 1, 15, 0).toISOString(),
   breakEnd: new Date(2025, 0, 1, 16, 0).toISOString(),
   bookingOpenDay: Weekday.monday,
-  bookingOpenTime: new Date(2025, 0, 1, 12, 0).toISOString(),
+  bookingOpenTime: new Date(1970, 0, 1, 12, 0).toISOString(), // 12pm
   updatedAt: new Date(2025, 0, 1).toISOString(),
   createdAt: new Date(2025, 0, 1).toISOString(),
 }
@@ -31,5 +31,5 @@ export const semesterCascadeCreateMock: CreateSemesterData = {
   breakStart: new Date(2025, 3, 14, 15, 0).toISOString(),
   breakEnd: new Date(2025, 3, 25, 12, 0).toISOString(),
   bookingOpenDay: "monday",
-  bookingOpenTime: new Date(2025, 0, 1, 12, 0).toISOString(),
+  bookingOpenTime: new Date(1970, 0, 1, 12, 0).toISOString(), // 12m
 }

--- a/apps/backend/src/test-config/mocks/Semester.mock.ts
+++ b/apps/backend/src/test-config/mocks/Semester.mock.ts
@@ -31,5 +31,5 @@ export const semesterCascadeCreateMock: CreateSemesterData = {
   breakStart: new Date(2025, 3, 14, 15, 0).toISOString(),
   breakEnd: new Date(2025, 3, 25, 12, 0).toISOString(),
   bookingOpenDay: "monday",
-  bookingOpenTime: new Date(1970, 0, 1, 12, 0).toISOString(), // 12m
+  bookingOpenTime: new Date(1970, 0, 1, 12, 0).toISOString(), // 12pm
 }

--- a/packages/shared/src/utils/booking.ts
+++ b/packages/shared/src/utils/booking.ts
@@ -1,0 +1,10 @@
+import { MAX_CASUAL_BOOKINGS, MAX_MEMBER_BOOKINGS } from "../constants"
+import type { User } from "../payload-types"
+import { MembershipType } from "../types"
+
+export const getMaxBookingSize = (user: User) => {
+  if (user.role === MembershipType.casual) {
+    return MAX_CASUAL_BOOKINGS
+  }
+  return MAX_MEMBER_BOOKINGS
+}

--- a/packages/shared/src/utils/date.ts
+++ b/packages/shared/src/utils/date.ts
@@ -40,7 +40,7 @@ export function getGameSessionOpenDay(semester: Semester, startTime: Date): Date
   const openTime = new Date(bookingOpenTime)
 
   const dayIndex = startTime.getUTCDay()
-  const day = Object.values(Weekday)[dayIndex] as Weekday
+  const day = Object.values(Weekday)[dayIndex]
   let daysDifference = getDaysBetweenWeekdays(bookingOpenDay as Weekday, day)
 
   // If the session is on the same day as bookingOpenDay, check the time

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -1,3 +1,4 @@
+export * from "./booking"
 export * from "./date"
 export type { Dayjs } from "./dayjs"
 export { dayjs } from "./dayjs"


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes towards the related issue. Please also  include relevant context. List any dependencies that are required for this change. -->

- Fixes #859 

I forgot to add the logic to check if users have reached their max booking sizes of (2 for members, 1 for casuals). I've fixed up the route and added an extra data service that lets a user fetch their bookings within the current booking week which determines if a user has reached their max limit. 

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added thorough tests that prove my fix is effective and that my feature works
- [x] I've requested a review from another user
