### PR TITLE
feat(onboarding): use fetched onboarding global

### DIFF
--- a/apps/frontend/src/app/onboarding/page.tsx
+++ b/apps/frontend/src/app/onboarding/page.tsx
@@ -1,10 +1,10 @@
 import { VStack } from "@yamada-ui/react"
-import { OnboardingClient } from "@/components/client/user/OnboardingClient"
+import { OnboardingServerSection } from "@/components/server/OnboardingServerSection"
 
 export default function OnboardingPage() {
   return (
     <VStack as="main">
-      <OnboardingClient />
+      <OnboardingServerSection />
     </VStack>
   )
 }

--- a/apps/frontend/src/components/client/user/OnboardingClient.tsx
+++ b/apps/frontend/src/components/client/user/OnboardingClient.tsx
@@ -1,10 +1,11 @@
 "use client"
 
+import type { OnboardingGlobal } from "@repo/shared"
 import { NotAuthorised, RegisterFlowSkeleton } from "@repo/ui/components/Generic"
 import { OnboardingSection } from "@/components/client/user/OnboardingSection"
 import { RoleGuard } from "@/context/RoleWrappers"
 
-export const OnboardingClient = () => {
+export const OnboardingClient = ({ onboardingGlobal }: { onboardingGlobal: OnboardingGlobal }) => {
   return (
     <RoleGuard
       fallback={
@@ -18,7 +19,7 @@ export const OnboardingClient = () => {
       }
       loading={<RegisterFlowSkeleton />}
     >
-      {(auth) => <OnboardingSection auth={auth} />}
+      {(auth) => <OnboardingSection auth={auth} onboardingGlobal={onboardingGlobal} />}
     </RoleGuard>
   )
 }

--- a/apps/frontend/src/components/client/user/OnboardingSection.test.tsx
+++ b/apps/frontend/src/components/client/user/OnboardingSection.test.tsx
@@ -2,6 +2,7 @@ import { casualUserMock } from "@repo/shared/mocks"
 import { mockAuthContextValue } from "@repo/shared/mocks/Authentication.mock"
 import { Gender, PlayLevel, University } from "@repo/shared/types"
 import type { AuthContextValueWithUser } from "@repo/shared/types/auth"
+import { mockOnboardingGlobal } from "@repo/ui/test-config/mocks/CasualInfoForm.mock"
 import { render, screen } from "@repo/ui/test-utils"
 import { OnboardingSection } from "./OnboardingSection"
 
@@ -25,12 +26,16 @@ describe("<OnboardingSection />", () => {
   })
 
   it("renders the register flow component", () => {
-    render(<OnboardingSection auth={mockAuthContextValue} />)
+    render(
+      <OnboardingSection auth={mockAuthContextValue} onboardingGlobal={mockOnboardingGlobal} />,
+    )
     expect(screen.getByText("Basic Info")).toBeInTheDocument()
   })
 
   it("should call handleComplete when registration is complete", async () => {
-    const { user } = render(<OnboardingSection auth={mockAuthContextValue} />)
+    const { user } = render(
+      <OnboardingSection auth={mockAuthContextValue} onboardingGlobal={mockOnboardingGlobal} />,
+    )
 
     // Basic Info Form 1
     await user.click(screen.getByText("Continue"))
@@ -87,7 +92,9 @@ describe("<OnboardingSection />", () => {
       },
     }
 
-    render(<OnboardingSection auth={mockAuthMissingFields} />)
+    render(
+      <OnboardingSection auth={mockAuthMissingFields} onboardingGlobal={mockOnboardingGlobal} />,
+    )
     expect(screen.getByText("Casual member information")).toBeInTheDocument()
   })
 
@@ -108,7 +115,7 @@ describe("<OnboardingSection />", () => {
       },
     }
 
-    render(<OnboardingSection auth={userWithOnlyPhone} />)
+    render(<OnboardingSection auth={userWithOnlyPhone} onboardingGlobal={mockOnboardingGlobal} />)
     expect(screen.getByText("Basic Info")).toBeInTheDocument()
   })
 
@@ -129,7 +136,7 @@ describe("<OnboardingSection />", () => {
       },
     }
 
-    render(<OnboardingSection auth={userWithOnlyGender} />)
+    render(<OnboardingSection auth={userWithOnlyGender} onboardingGlobal={mockOnboardingGlobal} />)
     expect(screen.getByText("Basic Info")).toBeInTheDocument()
   })
 
@@ -150,7 +157,12 @@ describe("<OnboardingSection />", () => {
       },
     }
 
-    render(<OnboardingSection auth={userWithUniversityAndGender} />)
+    render(
+      <OnboardingSection
+        auth={userWithUniversityAndGender}
+        onboardingGlobal={mockOnboardingGlobal}
+      />,
+    )
     expect(screen.getByText("Basic Info")).toBeInTheDocument()
   })
 })

--- a/apps/frontend/src/components/client/user/OnboardingSection.tsx
+++ b/apps/frontend/src/components/client/user/OnboardingSection.tsx
@@ -1,6 +1,12 @@
 "use client"
 
-import { type Gender, PlayLevel, type RegisterFlowState, type University } from "@repo/shared"
+import {
+  type Gender,
+  type OnboardingGlobal,
+  PlayLevel,
+  type RegisterFlowState,
+  type University,
+} from "@repo/shared"
 import type { AuthContextValueWithUser } from "@repo/shared/types/auth"
 import { RegisterFlow } from "@repo/ui/components/Generic"
 import { useRegisterFlowStorage } from "@repo/ui/hooks/storage/registerFlowStorage"
@@ -8,7 +14,13 @@ import { Container } from "@yamada-ui/react"
 import { useEffect } from "react"
 import { useUpdateSelfMutation } from "@/services/auth/AuthMutations"
 
-export const OnboardingSection = ({ auth }: { auth: AuthContextValueWithUser }) => {
+export const OnboardingSection = ({
+  auth,
+  onboardingGlobal,
+}: {
+  auth: AuthContextValueWithUser
+  onboardingGlobal: OnboardingGlobal
+}) => {
   const { user } = auth
   const { setValue } = useRegisterFlowStorage()
   const updateSelfMutation = useUpdateSelfMutation()
@@ -61,7 +73,7 @@ export const OnboardingSection = ({ auth }: { auth: AuthContextValueWithUser }) 
 
   return (
     <Container centerContent layerStyle="container">
-      <RegisterFlow handleComplete={handleComplete} />
+      <RegisterFlow handleComplete={handleComplete} onboardingGlobal={onboardingGlobal} />
     </Container>
   )
 }

--- a/apps/frontend/src/components/server/OnboardingServerSection.tsx
+++ b/apps/frontend/src/components/server/OnboardingServerSection.tsx
@@ -7,7 +7,7 @@ import { OnboardingClient } from "../client/user/OnboardingClient"
  * @returns An onboarding section component.
  */
 export const OnboardingServerSection = async () => {
-  const onboardingGlobal = await getOnboarding()
+  const onboardingResponse = await getOnboarding()
 
-  return <OnboardingClient onboardingGlobal={onboardingGlobal} />
+  return <OnboardingClient onboardingGlobal={onboardingResponse.data} />
 }

--- a/apps/frontend/src/components/server/OnboardingServerSection.tsx
+++ b/apps/frontend/src/components/server/OnboardingServerSection.tsx
@@ -1,0 +1,13 @@
+import { getOnboarding } from "@/services/cms/onboarding/OnboardingService"
+import { OnboardingClient } from "../client/user/OnboardingClient"
+
+/**
+ * Server-side component to fetch and render the onboarding section.
+ *
+ * @returns An onboarding section component.
+ */
+export const OnboardingServerSection = async () => {
+  const onboardingGlobal = await getOnboarding()
+
+  return <OnboardingClient onboardingGlobal={onboardingGlobal} />
+}

--- a/apps/frontend/src/services/cms/onboarding/OnboardingService.ts
+++ b/apps/frontend/src/services/cms/onboarding/OnboardingService.ts
@@ -1,4 +1,4 @@
-import { OnboardingGlobalSchema } from "@repo/shared"
+import { GetOnboardingResponseSchema } from "@repo/shared"
 import { cache } from "react"
 import { ApiClient, apiClient } from "@/lib/api/client"
 import { QueryKeys } from "@/services"
@@ -10,7 +10,7 @@ import { QueryKeys } from "@/services"
  * @throws When the API request fails
  */
 export const getOnboarding = cache(async () => {
-  const response = await apiClient.get("/api/globals/onboarding", OnboardingGlobalSchema, {
+  const response = await apiClient.get("/api/globals/onboarding", GetOnboardingResponseSchema, {
     tags: [QueryKeys.ONBOARDING],
   })
   return ApiClient.throwIfError(response)

--- a/packages/shared/src/schemas/globals/onboarding.ts
+++ b/packages/shared/src/schemas/globals/onboarding.ts
@@ -7,3 +7,7 @@ export const OnboardingGlobalSchema = z.object({
   updatedAt: z.string().optional().nullable(),
   createdAt: z.string().optional().nullable(),
 }) satisfies z.ZodType<Omit<Onboarding, "id">>
+
+export const GetOnboardingResponseSchema = z.object({
+  data: OnboardingGlobalSchema,
+})

--- a/packages/shared/src/types/globals/index.ts
+++ b/packages/shared/src/types/globals/index.ts
@@ -1,2 +1,3 @@
 export * from "./location-bubble"
+export * from "./onboarding"
 export * from "./terms-of-service"

--- a/packages/shared/src/types/globals/onboarding.ts
+++ b/packages/shared/src/types/globals/onboarding.ts
@@ -1,0 +1,5 @@
+import type { GetOnboardingResponseSchema, OnboardingGlobalSchema } from "src/schemas"
+import type { z } from "zod"
+
+export type OnboardingGlobal = z.infer<typeof OnboardingGlobalSchema>
+export type GetOnboardingResponse = z.infer<typeof GetOnboardingResponseSchema>

--- a/packages/shared/src/types/globals/onboarding.ts
+++ b/packages/shared/src/types/globals/onboarding.ts
@@ -1,5 +1,5 @@
-import type { GetOnboardingResponseSchema, OnboardingGlobalSchema } from "src/schemas"
 import type { z } from "zod"
+import type { GetOnboardingResponseSchema, OnboardingGlobalSchema } from "../../schemas/globals"
 
 export type OnboardingGlobal = z.infer<typeof OnboardingGlobalSchema>
 export type GetOnboardingResponse = z.infer<typeof GetOnboardingResponseSchema>

--- a/packages/ui/src/components/Generic/RegisterFlow/CasualInfoForm/CasualInfoForm.stories.tsx
+++ b/packages/ui/src/components/Generic/RegisterFlow/CasualInfoForm/CasualInfoForm.stories.tsx
@@ -1,3 +1,4 @@
+import { mockCasualMemberInformation } from "@repo/ui/test-config/mocks/CasualInfoForm.mock"
 import type { Meta, StoryObj } from "@storybook/react"
 import { VStack } from "@yamada-ui/react"
 import { CasualInfoForm } from "./CasualInfoForm"
@@ -12,9 +13,22 @@ const meta = {
       </VStack>
     ),
   ],
+  argTypes: {
+    casualMemberInformation: {
+      control: "object",
+      description: "Rich text data displayed in the form",
+      table: {
+        type: { summary: "OnboardingGlobal['casualMemberInformation']" },
+      },
+    },
+  },
 } satisfies Meta<typeof CasualInfoForm>
 
 export default meta
 type Story = StoryObj<typeof CasualInfoForm>
 
-export const Default: Story = {}
+export const Default: Story = {
+  args: {
+    casualMemberInformation: mockCasualMemberInformation,
+  },
+}

--- a/packages/ui/src/components/Generic/RegisterFlow/CasualInfoForm/CasualInfoForm.test.tsx
+++ b/packages/ui/src/components/Generic/RegisterFlow/CasualInfoForm/CasualInfoForm.test.tsx
@@ -1,4 +1,5 @@
 import type { CasualInfoFormValues } from "@repo/shared/types"
+import { mockCasualMemberInformation } from "@repo/ui/test-config/mocks/CasualInfoForm.mock"
 import { render, screen } from "@repo/ui/test-utils"
 import { isValidElement } from "react"
 import * as CasualInfoFormModule from "./index"
@@ -7,7 +8,13 @@ import { CasualInfoForm } from "./index"
 describe("<CasualInfoForm />", () => {
   it("should re-export the CasualInfoForm component and check if CasualInfoForm exists", () => {
     expect(CasualInfoFormModule.CasualInfoForm).toBeDefined()
-    expect(isValidElement(<CasualInfoFormModule.CasualInfoForm />)).toBeTruthy()
+    expect(
+      isValidElement(
+        <CasualInfoFormModule.CasualInfoForm
+          casualMemberInformation={mockCasualMemberInformation}
+        />,
+      ),
+    ).toBeTruthy()
   })
 
   it("should have correct displayName", () => {
@@ -17,7 +24,12 @@ describe("<CasualInfoForm />", () => {
   it("should call onSubmit when a user clicks the submit button after checking the box", async () => {
     const handleSubmit = vi.fn((data: CasualInfoFormValues) => data)
 
-    const { user } = render(<CasualInfoForm onSubmit={handleSubmit} />)
+    const { user } = render(
+      <CasualInfoForm
+        casualMemberInformation={mockCasualMemberInformation}
+        onSubmit={handleSubmit}
+      />,
+    )
 
     await user.click(await screen.findByTestId("agree"))
 
@@ -25,5 +37,20 @@ describe("<CasualInfoForm />", () => {
     await user.click(submitButton)
 
     expect(handleSubmit).toBeCalled()
+  })
+
+  it("should correctly display the casual member information", () => {
+    render(<CasualInfoForm casualMemberInformation={mockCasualMemberInformation} />)
+
+    expect(screen.getByText("Casual members can only attend 1 session a week.")).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        "It is $10 per session and is to be paid before attending to secure your spot. We will send you an email for this, please do not pay unless we reach out to you.",
+      ),
+    ).toBeInTheDocument()
+    expect(screen.getByText("We aim to prioritize members over casuals!")).toBeInTheDocument()
+    expect(
+      screen.getByText("The number of casuals allowed per session may vary dependent on capacity"),
+    ).toBeInTheDocument()
   })
 })

--- a/packages/ui/src/components/Generic/RegisterFlow/CasualInfoForm/CasualInfoForm.tsx
+++ b/packages/ui/src/components/Generic/RegisterFlow/CasualInfoForm/CasualInfoForm.tsx
@@ -1,19 +1,16 @@
 "use client"
 
 import type { CasualInfoFormValues, OnboardingGlobal } from "@repo/shared/types"
+import { RichText, type RichTextProps } from "@repo/ui/components/Generic/RichText"
 import { Button, Heading } from "@repo/ui/components/Primitive"
 import { UserRoundIcon } from "@yamada-ui/lucide"
-
 import {
   Card,
   CardBody,
   CardFooter,
   Center,
   Checkbox,
-  DecimalList,
-  For,
   FormControl,
-  ListItem,
   memo,
   noop,
   VStack,
@@ -36,7 +33,11 @@ export interface CasualInfoFormProps {
   /**
    *
    */
-  onboardingGlobal: OnboardingGlobal
+  casualMemberInformation: OnboardingGlobal["casualMemberInformation"]
+  /**
+   *
+   */
+  richTextProps?: Omit<RichTextProps, "data">
 }
 
 /**
@@ -48,73 +49,60 @@ export interface CasualInfoFormProps {
  * @param props CasualInfoForm component props
  * @returns The form component
  */
-export const CasualInfoForm: FC<CasualInfoFormProps> = memo(({ defaultValues, onSubmit }) => {
-  const {
-    control,
-    handleSubmit,
-    formState: { errors, isSubmitting },
-  } = useForm<CasualInfoFormValues>()
+export const CasualInfoForm: FC<CasualInfoFormProps> = memo(
+  ({ defaultValues, onSubmit, casualMemberInformation, richTextProps }) => {
+    const {
+      control,
+      handleSubmit,
+      formState: { errors, isSubmitting },
+    } = useForm<CasualInfoFormValues>()
 
-  return (
-    <VStack
-      as="form"
-      bgColor="inherit"
-      h="full"
-      justifyContent="space-between"
-      onSubmit={handleSubmit(onSubmit ?? noop)}
-    >
-      <VStack>
-        <Center>
-          <UserRoundIcon fontSize="9xl" />
-        </Center>
+    return (
+      <VStack
+        as="form"
+        bgColor="inherit"
+        h="full"
+        justifyContent="space-between"
+        onSubmit={handleSubmit(onSubmit ?? noop)}
+      >
+        <VStack>
+          <Center>
+            <UserRoundIcon fontSize="9xl" />
+          </Center>
 
-        <Heading.h3 textAlign="center">Casual member information</Heading.h3>
+          <Heading.h3 textAlign="center">Casual member information</Heading.h3>
 
-        <Card bgColor="secondary" borderRadius="xl" layerStyle="gradientBorder">
-          <CardBody>
-            <DecimalList>
-              <For
-                each={[
-                  "Casual members can only attend 1 session a week.",
-                  "It is $8 per session and is to be paid before attending to secure your spot. We will send you an email for this, please do not pay unless we reach out to you.",
-                  "We aim to prioritize members over casuals!",
-                  "The number of casuals allowed per session may vary dependent on capacity.",
-                ]}
-              >
-                {(text, index) => (
-                  <ListItem key={index} textWrap="wrap">
-                    {text}
-                  </ListItem>
-                )}
-              </For>
-            </DecimalList>
-          </CardBody>
-          <CardFooter>
-            <FormControl errorMessage={errors.agree?.message} invalid={!!errors.agree}>
-              <Controller
-                control={control}
-                defaultValue={defaultValues?.agree}
-                name="agree"
-                render={({ field: { onChange, onBlur, value } }) => (
-                  <Checkbox
-                    checked={value}
-                    data-testid="agree"
-                    label="I agree"
-                    onBlur={onBlur}
-                    onChange={onChange}
-                  />
-                )}
-                rules={{ required: { value: true, message: "Please agree to continue" } }}
-              />
-            </FormControl>
-          </CardFooter>
-        </Card>
+          <Card bgColor="secondary" borderRadius="xl" layerStyle="gradientBorder">
+            <CardBody>
+              <RichText data={casualMemberInformation} {...richTextProps} />
+            </CardBody>
+            <CardFooter>
+              <FormControl errorMessage={errors.agree?.message} invalid={!!errors.agree}>
+                <Controller
+                  control={control}
+                  defaultValue={defaultValues?.agree}
+                  name="agree"
+                  render={({ field: { onChange, onBlur, value } }) => (
+                    <Checkbox
+                      checked={value}
+                      data-testid="agree"
+                      label="I agree"
+                      onBlur={onBlur}
+                      onChange={onChange}
+                    />
+                  )}
+                  rules={{ required: { value: true, message: "Please agree to continue" } }}
+                />
+              </FormControl>
+            </CardFooter>
+          </Card>
+        </VStack>
+        <Button colorScheme="primary" loading={isSubmitting} type="submit">
+          Continue
+        </Button>
       </VStack>
-      <Button colorScheme="primary" loading={isSubmitting} type="submit">
-        Continue
-      </Button>
-    </VStack>
-  )
-})
+    )
+  },
+)
 
 CasualInfoForm.displayName = "CasualInfoForm"

--- a/packages/ui/src/components/Generic/RegisterFlow/CasualInfoForm/CasualInfoForm.tsx
+++ b/packages/ui/src/components/Generic/RegisterFlow/CasualInfoForm/CasualInfoForm.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import type { CasualInfoFormValues } from "@repo/shared/types"
+import type { CasualInfoFormValues, OnboardingGlobal } from "@repo/shared/types"
 import { Button, Heading } from "@repo/ui/components/Primitive"
 import { UserRoundIcon } from "@yamada-ui/lucide"
 
@@ -33,6 +33,10 @@ export interface CasualInfoFormProps {
    * Submit handler called when user submits the form.
    */
   onSubmit?: SubmitHandler<CasualInfoFormValues>
+  /**
+   *
+   */
+  onboardingGlobal: OnboardingGlobal
 }
 
 /**

--- a/packages/ui/src/components/Generic/RegisterFlow/RegisterFlow.stories.tsx
+++ b/packages/ui/src/components/Generic/RegisterFlow/RegisterFlow.stories.tsx
@@ -1,3 +1,4 @@
+import { mockOnboardingGlobal } from "@repo/ui/test-config/mocks/CasualInfoForm.mock"
 import type { Meta, StoryObj } from "@storybook/react"
 import { RegisterFlow } from "./RegisterFlow"
 import { RegisterFlowSkeleton } from "./RegisterFlowSkeleton"
@@ -10,7 +11,11 @@ const meta = {
 export default meta
 type Story = StoryObj<typeof RegisterFlow>
 
-export const Default: Story = {}
+export const Default: Story = {
+  args: {
+    onboardingGlobal: mockOnboardingGlobal,
+  },
+}
 
 export const Skeleton: Story = {
   render: () => <RegisterFlowSkeleton />,

--- a/packages/ui/src/components/Generic/RegisterFlow/RegisterFlow.test.tsx
+++ b/packages/ui/src/components/Generic/RegisterFlow/RegisterFlow.test.tsx
@@ -1,5 +1,6 @@
 import { Gender, PlayLevel, University } from "@repo/shared/types"
 import { setupTestEnvironment } from "@repo/ui/test-config/localStorage-test-utils"
+import { mockOnboardingGlobal } from "@repo/ui/test-config/mocks/CasualInfoForm.mock"
 import { render, screen } from "@repo/ui/test-utils"
 import { isValidElement } from "react"
 import * as RegisterFlowModule from "./index"
@@ -12,7 +13,9 @@ describe("<RegisterFlow />", () => {
 
   it("should re-export the RegisterFlow component and check if RegisterFlow exists", () => {
     expect(RegisterFlowModule.RegisterFlow).toBeDefined()
-    expect(isValidElement(<RegisterFlowModule.RegisterFlow />)).toBeTruthy()
+    expect(
+      isValidElement(<RegisterFlowModule.RegisterFlow onboardingGlobal={mockOnboardingGlobal} />),
+    ).toBeTruthy()
   })
 
   it("should have correct displayName", () => {
@@ -21,7 +24,9 @@ describe("<RegisterFlow />", () => {
 
   it("should progress through the entire register flow and display the Register Success Panel and handle submission once complete", async () => {
     const handleComplete = vi.fn()
-    const { user } = render(<RegisterFlow handleComplete={handleComplete} />)
+    const { user } = render(
+      <RegisterFlow handleComplete={handleComplete} onboardingGlobal={mockOnboardingGlobal} />,
+    )
 
     // Basic Info Form 1
     expect(screen.getByTestId("go-back")).toBeDisabled()
@@ -60,7 +65,7 @@ describe("<RegisterFlow />", () => {
   }, 10_000)
 
   it("should return to the previous step when the go back button is pressed, and pre-fill the fields", async () => {
-    const { user } = render(<RegisterFlow />)
+    const { user } = render(<RegisterFlow onboardingGlobal={mockOnboardingGlobal} />)
 
     const sampleFirstName = "Brandon"
     const sampleLastName = "Chan"

--- a/packages/ui/src/components/Generic/RegisterFlow/RegisterFlow.tsx
+++ b/packages/ui/src/components/Generic/RegisterFlow/RegisterFlow.tsx
@@ -180,10 +180,11 @@ export const RegisterFlow = memo(({ handleComplete, onboardingGlobal }: Register
       title: "Casual Member Info",
       element: (
         <CasualInfoForm
+          casualMemberInformation={onboardingGlobal.casualMemberInformation}
           defaultValues={state.casualInfo ?? undefined}
           key="casual-info-form-1"
-          onboardingGlobal={onboardingGlobal}
           onSubmit={handleStepSubmit("SET_CASUAL_INFO")}
+          richTextProps={{ mediaBaseUrl: process.env.NEXT_PUBLIC_API_URL }}
         />
       ),
     },

--- a/packages/ui/src/components/Generic/RegisterFlow/RegisterFlow.tsx
+++ b/packages/ui/src/components/Generic/RegisterFlow/RegisterFlow.tsx
@@ -5,6 +5,7 @@ import type {
   BasicInfoForm1Values,
   BasicInfoForm2Values,
   CasualInfoFormValues,
+  OnboardingGlobal,
   RegisterFlowState,
   UniversityInfoFormValues,
 } from "@repo/shared/types"
@@ -97,6 +98,10 @@ interface RegisterFlowProps {
    * Callback function to handle the completion of the registration flow.
    */
   handleComplete?: (state: RegisterFlowState) => Promise<void>
+  /**
+   *
+   */
+  onboardingGlobal: OnboardingGlobal
 }
 
 /**
@@ -105,7 +110,7 @@ interface RegisterFlowProps {
  * @param handleComplete Callback function to handle the completion of the registration flow.
  * @returns The RegisterFlow component with all steps and forms.
  */
-export const RegisterFlow = memo(({ handleComplete }: RegisterFlowProps) => {
+export const RegisterFlow = memo(({ handleComplete, onboardingGlobal }: RegisterFlowProps) => {
   const { value: persistedState, setValue: setPersistedState } = useRegisterFlowStorage()
 
   const [state, dispatch] = useReducer(reducer, persistedState ?? initialState)
@@ -177,6 +182,7 @@ export const RegisterFlow = memo(({ handleComplete }: RegisterFlowProps) => {
         <CasualInfoForm
           defaultValues={state.casualInfo ?? undefined}
           key="casual-info-form-1"
+          onboardingGlobal={onboardingGlobal}
           onSubmit={handleStepSubmit("SET_CASUAL_INFO")}
         />
       ),

--- a/packages/ui/src/test-config/mocks/CasualInfoForm.mock.ts
+++ b/packages/ui/src/test-config/mocks/CasualInfoForm.mock.ts
@@ -1,0 +1,15 @@
+import { ListType } from "@repo/ui/components/Generic"
+import { createEditorState, createListNode } from "@repo/ui/test-config/mocks/RichText.mock"
+
+export const mockCasualMemberInformation = createEditorState([
+  createListNode(ListType.ORDERED, [
+    "Casual members can only attend 1 session a week.",
+    "It is $10 per session and is to be paid before attending to secure your spot. We will send you an email for this, please do not pay unless we reach out to you.",
+    "We aim to prioritize members over casuals!",
+    "The number of casuals allowed per session may vary dependent on capacity",
+  ]),
+])
+
+export const mockOnboardingGlobal = {
+  casualMemberInformation: mockCasualMemberInformation,
+}


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes towards the related issue. Please also  include relevant context. List any dependencies that are required for this change. -->

- Changed the schema used in the `OnboardingService` to correctly parse the api response that uses `data: { ... }`
- Created `OnboardingServerSection` that fetches the onboarding global at build time and passes the data down to the `RegisterFlow` and `CasualInfoForm` components

Fixes #838 

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

<img width="1868" height="1197" alt="Screenshot 2025-10-04 at 15 01 04" src="https://github.com/user-attachments/assets/9424c514-99f1-4848-a187-72bf9f56ed51" />

- [x] Manual testing (requires screenshots or videos)
- [x] Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added thorough tests that prove my fix is effective and that my feature works
- [x] I've requested a review from another user
