### PR TITLE
Refactor backend booking emails to use shared date utils

### DIFF
--- a/apps/backend/src/business-layer/services/MailService.test.ts
+++ b/apps/backend/src/business-layer/services/MailService.test.ts
@@ -1,4 +1,5 @@
-import { dayjs } from "@repo/shared"
+import { formatDayMonth, formatTime24Hour, formatWeekday } from "@repo/shared"
+import type { GameSession } from "@repo/shared/payload-types"
 import { payload } from "@/data-layer/adapters/Payload"
 import { bookingMock, bookingWithGameSessionScheduleMock } from "@/test-config/mocks/Booking.mock"
 import MailService from "./MailService"
@@ -54,8 +55,8 @@ describe("MailService", () => {
     })
 
     it("should handle bookings with a game session schedule", async () => {
-      const NOW = dayjs(new Date())
       const sendEmailMock = vi.spyOn(payload, "sendEmail").mockResolvedValueOnce({ success: true })
+      const gameSession = bookingWithGameSessionScheduleMock.gameSession as GameSession
 
       await MailService.sendBookingConfirmation(bookingWithGameSessionScheduleMock)
 
@@ -63,8 +64,8 @@ describe("MailService", () => {
 
       const expectedStrings = [
         "Your booking for our Monday session at UoA Rec Center has been confirmed!",
-        `Date: <!-- -->Monday<!-- --> <!-- -->${NOW.format("D MMMM")}`,
-        `Time: <!-- -->${NOW.format("HH:mm")}<!-- --> - <!-- -->${NOW.format("HH:mm")}`,
+        `Date: <!-- -->Monday<!-- --> <!-- -->${formatDayMonth(gameSession.startTime)}`,
+        `Time: <!-- -->${formatTime24Hour(gameSession.startTime)}<!-- --> - <!-- -->${formatTime24Hour(gameSession.endTime)}`,
         "Location: <!-- -->UoA Rec Center<!-- -->, <!-- -->17 Symonds Street",
       ]
 
@@ -81,18 +82,19 @@ describe("MailService", () => {
     })
 
     it("should handle bookings without a game session schedule", async () => {
-      const NOW = dayjs(new Date())
       const sendEmailMock = vi.spyOn(payload, "sendEmail").mockResolvedValueOnce({ success: true })
+      const gameSession = bookingMock.gameSession as GameSession
+      const weekday = formatWeekday(gameSession.startTime)
 
       await MailService.sendBookingConfirmation(bookingMock)
 
       const htmlContent = sendEmailMock.mock.calls[0][0].html
 
       const expectedStrings = [
-        `Your booking for our ${NOW.format("dddd")} session at UoA Rec Center has been confirmed!`,
-        `Date: <!-- -->${NOW.format("dddd").charAt(0) + NOW.format("dddd").slice(1)}<!-- --> <!-- -->${NOW.format("D MMMM")}`,
+        `Your booking for our ${weekday} session at UoA Rec Center has been confirmed!`,
+        `Date: <!-- -->${weekday}<!-- --> <!-- -->${formatDayMonth(gameSession.startTime)}`,
         "Location: <!-- -->UoA Rec Center<!-- -->, <!-- -->17 Symonds Street",
-        `Time: <!-- -->${NOW.format("HH:mm")}<!-- --> - <!-- -->${NOW.format("HH:mm")}`,
+        `Time: <!-- -->${formatTime24Hour(gameSession.startTime)}<!-- --> - <!-- -->${formatTime24Hour(gameSession.endTime)}`,
       ]
 
       expectedStrings.forEach((expectedString) => {
@@ -102,7 +104,7 @@ describe("MailService", () => {
       expect(sendEmailMock).toHaveBeenCalledWith({
         to: "straight.zhao@casual.com",
         replyTo: ["badminton.au@gmail.com", "uabcbookings@gmail.com"],
-        subject: `UABC - ${NOW.format("dddd")} Booking Confirmation`,
+        subject: `UABC - ${weekday} Booking Confirmation`,
         html: expect.any(String),
       })
     })

--- a/apps/backend/src/business-layer/services/MailService.ts
+++ b/apps/backend/src/business-layer/services/MailService.ts
@@ -1,5 +1,5 @@
 import { render } from "@react-email/components"
-import { capitalize, dayjs } from "@repo/shared"
+import { capitalize, formatDayMonth, formatTime24Hour, formatWeekday } from "@repo/shared"
 import type { Booking, GameSession, GameSessionSchedule, User } from "@repo/shared/payload-types"
 import { payload } from "@/data-layer/adapters/Payload"
 import BookingConfirmationEmail from "@/emails/BookingConfirmationEmail"
@@ -30,11 +30,11 @@ export default class MailService {
     const gameSession = booking.gameSession as GameSession
     const gameSessionSchedule = gameSession.gameSessionSchedule as GameSessionSchedule | undefined
 
-    const date = dayjs(gameSession.startTime).format("D MMMM")
-    const rawWeekday = gameSessionSchedule?.day || dayjs(gameSession.startTime).format("dddd")
+    const date = formatDayMonth(gameSession.startTime)
+    const rawWeekday = gameSessionSchedule?.day || formatWeekday(gameSession.startTime)
     const weekday = capitalize(rawWeekday)
-    const startTime = dayjs(gameSession.startTime).format("HH:mm")
-    const endTime = dayjs(gameSession.endTime).format("HH:mm")
+    const startTime = formatTime24Hour(gameSession.startTime)
+    const endTime = formatTime24Hour(gameSession.endTime)
     const sessionName = (gameSessionSchedule?.name ?? gameSession.name) as string
     const sessionLocation = (gameSessionSchedule?.location ?? gameSession.location) as string
     const html = await render(

--- a/apps/backend/src/utils/date.test.ts
+++ b/apps/backend/src/utils/date.test.ts
@@ -1,6 +1,9 @@
 import {
   formatDate,
+  formatDayMonth,
   formatTime,
+  formatTime24Hour,
+  formatWeekday,
   GameSessionStatus,
   getDateTimeStatus,
   getDaysBetweenWeekdays,
@@ -284,6 +287,27 @@ describe("formatDate", () => {
   it("should format different dates correctly", () => {
     expect(formatDate(new Date("2025-12-25T12:00:00Z"))).toBe("Thursday, 25/12/25")
     expect(formatDate(new Date("2025-06-15T09:30:00Z"))).toBe("Sunday, 15/06/25")
+  })
+})
+
+describe("formatWeekday", () => {
+  it("should format weekday names correctly", () => {
+    expect(formatWeekday("2025-01-06T09:30:00Z")).toBe("Monday")
+    expect(formatWeekday("2025-01-07T09:30:00Z")).toBe("Tuesday")
+  })
+})
+
+describe("formatDayMonth", () => {
+  it("should format day and month correctly", () => {
+    expect(formatDayMonth("2025-01-06T09:30:00Z")).toBe("6 January")
+    expect(formatDayMonth("2025-12-25T12:00:00Z")).toBe("25 December")
+  })
+})
+
+describe("formatTime24Hour", () => {
+  it("should format time in 24-hour format correctly", () => {
+    expect(formatTime24Hour("2025-01-06T09:30:00Z")).toBe("09:30")
+    expect(formatTime24Hour("2025-01-06T14:05:00Z")).toBe("14:05")
   })
 })
 

--- a/packages/shared/src/utils/date.ts
+++ b/packages/shared/src/utils/date.ts
@@ -29,6 +29,36 @@ export function formatDateWithOrdinal(date: string | Date): string {
 }
 
 /**
+ * Formats a date-like value as a full weekday name.
+ *
+ * @param date The date-like value to format
+ * @returns Weekday name such as "Monday"
+ */
+export function formatWeekday(date: string | Date): string {
+  return dayjs(date).format("dddd")
+}
+
+/**
+ * Formats a date-like value as day and month.
+ *
+ * @param date The date-like value to format
+ * @returns Formatted value such as "1 January"
+ */
+export function formatDayMonth(date: string | Date): string {
+  return dayjs(date).format("D MMMM")
+}
+
+/**
+ * Formats a date-like value as a 24-hour time.
+ *
+ * @param date The date-like value to format
+ * @returns Formatted time such as "09:30"
+ */
+export function formatTime24Hour(date: string | Date): string {
+  return dayjs(date).format("HH:mm")
+}
+
+/**
  * Calculates the open date for a session based on the start time, open day, and open time.
  *
  * @param semester The {@link Semester} object containing booking open day and time


### PR DESCRIPTION
# Description

- Fixes N/A
- Route backend booking email formatting through shared date utilities backed by the configured `dayjs.ts` wrapper
- Add helper coverage plus a route-level integration test for the rendered booking confirmation email payload

## Type of change

- [x] New feature or improvement (non-breaking change which adds/modifies functionality)

# How Has This Been Tested?

- [x] Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added thorough tests that prove my fix is effective and that my feature works
- [ ] Additional issues have been created for any tech debt left in this PR
- [ ] I've requested a review from another user
